### PR TITLE
feat: 게시글 등록, 조회 API 구현

### DIFF
--- a/vitalroutes/src/main/java/swyg/vitalroutes/Image/domain/Image.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/Image/domain/Image.java
@@ -1,0 +1,42 @@
+package swyg.vitalroutes.Image.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import swyg.vitalroutes.post.domain.Post;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Image {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long imageId;
+    String titleImg;
+
+    @OneToMany(mappedBy = "image",cascade = CascadeType.ALL)
+    private List<Location> locations = new ArrayList<>();
+
+    @OneToOne(mappedBy = "image", fetch = FetchType.LAZY)
+    private Post post;
+
+    public void setImageInLocation(Location location) {
+        location.setImage(this);
+    }
+
+    public static Image crateImage(String titleImg, List<Location> locations) {
+        Image image = new Image();
+        image.setTitleImg(titleImg);
+        for (Location location : locations) {
+            image.setImageInLocation(location);
+        }
+        image.setLocations(locations);
+        return image;
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/Image/domain/Location.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/Image/domain/Location.java
@@ -1,0 +1,34 @@
+package swyg.vitalroutes.Image.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Location {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long locationId;
+    private int sequence;
+    private String fileName;
+    private String latitude;
+    private String longitude;
+
+    @ManyToOne
+    @JoinColumn(name = "image_id")
+    private Image image;
+
+    public static Location createLocation(int seq, String fileName, String[] info) {
+        Location location = new Location();
+        location.setSequence(seq);
+        location.setFileName(fileName);
+        location.setLatitude(info[0]);
+        location.setLongitude(info[1]);
+        return location;
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/Image/repository/ImageRepository.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/Image/repository/ImageRepository.java
@@ -1,0 +1,18 @@
+package swyg.vitalroutes.Image.repository;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import swyg.vitalroutes.Image.domain.Image;
+
+@Repository
+@RequiredArgsConstructor
+public class ImageRepository {
+    private final EntityManager em;
+
+    public Image findImageByPostId(Long postId) {
+        return em.createQuery("select i from Image i where i.post.id = :postId", Image.class)
+                .setParameter("postId", postId)
+                .getSingleResult();
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/controller/ApiExceptionController.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/controller/ApiExceptionController.java
@@ -1,0 +1,54 @@
+package swyg.vitalroutes.common.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import swyg.vitalroutes.common.exception.*;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class ApiExceptionController {
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<?> fileSizeExceeded() {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", "파일 용량이 초과하였습니다"));
+    }
+
+    // 파일이 이미지 타입이 아닌 경우
+    @ExceptionHandler(FileTypeNotMatchException.class)
+    public ResponseEntity<?> fileTypeNotMatching(FileTypeNotMatchException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", exception.getMessage()));
+    }
+
+    // 파일 내부에 GPS 정보가 없는 경우
+    @ExceptionHandler(FileNotEnoughInformationException.class)
+    public ResponseEntity<?> fileNotHaveGpsInfo(FileNotEnoughInformationException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", exception.getMessage()));
+    }
+
+    // 파일이 두 개 이상 전달되지 않은 경우
+    @ExceptionHandler(FileNotEnoughException.class)
+    public ResponseEntity<?> fileNotEnough(FileNotEnoughException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", exception.getMessage()));
+    }
+
+    // MultiPartFile 을 File 로 변환하는데 실패
+    @ExceptionHandler(FailedConversionFileException.class)
+    public ResponseEntity<?> failedConversionFile(FailedConversionFileException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", exception.getMessage()));
+    }
+
+    // 파일의 메타정보를 읽는데 실패
+    @ExceptionHandler(FailedReadImageException.class)
+    public ResponseEntity<?> failedReadImage(FailedReadImageException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", exception.getMessage()));
+    }
+
+    // Post 입력값이 맞지 않는 경우
+    @ExceptionHandler(InputViolateException.class)
+    public ResponseEntity<?> inputIsViolated(InputViolateException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", exception.getMessage()));
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/dto/ApiResponseDto.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/dto/ApiResponseDto.java
@@ -1,0 +1,10 @@
+package swyg.vitalroutes.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ApiResponseDto<T> {
+    private T data;
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/FailedConversionFileException.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/FailedConversionFileException.java
@@ -1,0 +1,7 @@
+package swyg.vitalroutes.common.exception;
+
+public class FailedConversionFileException extends RuntimeException {
+    public FailedConversionFileException(String message) {
+        super(message);
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/FailedReadImageException.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/FailedReadImageException.java
@@ -1,0 +1,7 @@
+package swyg.vitalroutes.common.exception;
+
+public class FailedReadImageException extends RuntimeException{
+    public FailedReadImageException(String message) {
+        super(message);
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/FileNotEnoughException.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/FileNotEnoughException.java
@@ -1,0 +1,7 @@
+package swyg.vitalroutes.common.exception;
+
+public class FileNotEnoughException extends RuntimeException {
+    public FileNotEnoughException(String message) {
+        super(message);
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/FileNotEnoughInformationException.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/FileNotEnoughInformationException.java
@@ -1,0 +1,7 @@
+package swyg.vitalroutes.common.exception;
+
+public class FileNotEnoughInformationException extends RuntimeException {
+    public FileNotEnoughInformationException(String message) {
+        super(message);
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/FileTypeNotMatchException.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/FileTypeNotMatchException.java
@@ -1,0 +1,7 @@
+package swyg.vitalroutes.common.exception;
+
+public class FileTypeNotMatchException extends RuntimeException{
+    public FileTypeNotMatchException(String message) {
+        super(message);
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/InputViolateException.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/InputViolateException.java
@@ -1,0 +1,7 @@
+package swyg.vitalroutes.common.exception;
+
+public class InputViolateException extends RuntimeException {
+    public InputViolateException(String message) {
+        super(message);
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/file/FileUtils.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/file/FileUtils.java
@@ -1,0 +1,71 @@
+package swyg.vitalroutes.common.file;
+
+import com.drew.imaging.ImageMetadataReader;
+import com.drew.imaging.ImageProcessingException;
+import com.drew.metadata.Metadata;
+import com.drew.metadata.exif.GpsDirectory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.multipart.MultipartFile;
+import swyg.vitalroutes.common.exception.FailedConversionFileException;
+import swyg.vitalroutes.common.exception.FailedReadImageException;
+import swyg.vitalroutes.common.exception.FileNotEnoughInformationException;
+import swyg.vitalroutes.common.exception.FileTypeNotMatchException;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+@Slf4j
+public class FileUtils {
+    public static File multipartFileToFile(MultipartFile multipartFile) throws IOException {
+        String originalFilename = multipartFile.getOriginalFilename();
+        String contentType = multipartFile.getContentType();
+        log.info("originalFilename = {}", originalFilename);
+        log.info("contentType = {}", contentType);
+
+        if (!contentType.startsWith("image")) {
+            throw new FileTypeNotMatchException("이미지 파일만 업로드 가능합니다");
+        }
+
+        File convFile = new File(originalFilename);
+        FileOutputStream fos = new FileOutputStream(convFile);
+        fos.write(multipartFile.getBytes());
+        fos.close();
+        return convFile;
+    }
+
+    public static String[] getLocationInfo(MultipartFile multipartFile) {
+        String latitude = "";
+        String longitude = "";
+        try {
+            File file = multipartFileToFile(multipartFile);
+            Metadata metadata = ImageMetadataReader.readMetadata(file);
+            GpsDirectory gpsDirectory = metadata.getFirstDirectoryOfType(GpsDirectory.class);
+
+            if (gpsDirectory == null || gpsDirectory.isEmpty()) {
+                throw new FileNotEnoughInformationException("파일에 GPS 정보가 없습니다");
+            }
+
+            if (gpsDirectory.containsTag(GpsDirectory.TAG_LATITUDE) && gpsDirectory.containsTag(GpsDirectory.TAG_LONGITUDE)) {
+                latitude = String.valueOf(gpsDirectory.getGeoLocation().getLatitude()); // 위도
+                longitude = String.valueOf(gpsDirectory.getGeoLocation().getLongitude());    // 경도
+            }
+
+            if (file.exists()) {
+                if (file.delete()) {
+                    log.info("파일 삭제 성공");
+                } else {
+                    log.info("파일 삭제 실패");
+                }
+            }
+
+            log.info("latitude = {}", latitude);
+            log.info("longitude = {}", longitude);
+        } catch (IOException e) {
+            throw new FailedConversionFileException("파일 변환에 실패하였습니다");
+        } catch (ImageProcessingException e) {
+            throw new FailedReadImageException("이미지 정보를 읽을 수 없습니다");
+        }
+        return new String[]{latitude, longitude};
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/hashtag/domain/HashTag.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/hashtag/domain/HashTag.java
@@ -1,0 +1,13 @@
+package swyg.vitalroutes.hashtag.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class HashTag {
+    @Id
+    private String tagId; // 태그의 영문을 Key 로 사용
+    private String tagName;
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/hashtag/domain/PostMappingTag.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/hashtag/domain/PostMappingTag.java
@@ -1,0 +1,32 @@
+package swyg.vitalroutes.hashtag.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import swyg.vitalroutes.post.domain.Post;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostMappingTag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long mappingId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id")
+    private HashTag hashTag;
+
+    public static PostMappingTag createPostMapTag(HashTag hashTag) {
+        PostMappingTag postMappingTag = new PostMappingTag();
+        postMappingTag.setHashTag(hashTag);
+        return postMappingTag;
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/hashtag/repository/HashTagRepository.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/hashtag/repository/HashTagRepository.java
@@ -1,0 +1,17 @@
+package swyg.vitalroutes.hashtag.repository;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import swyg.vitalroutes.hashtag.domain.HashTag;
+
+@Repository
+@RequiredArgsConstructor
+public class HashTagRepository {
+
+    private final EntityManager em;
+
+    public HashTag findTag(String tagId) {
+        return em.find(HashTag.class, tagId);
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/Member.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/Member.java
@@ -1,0 +1,21 @@
+package swyg.vitalroutes.member.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long memberId;
+    private String profile;
+    private String name;
+    private String email;
+    private String password;
+    private String country;
+    private String socialId;
+
+    @Enumerated(EnumType.STRING)
+    private SocialType socialType;
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/SocialType.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/SocialType.java
@@ -1,0 +1,5 @@
+package swyg.vitalroutes.member.domain;
+
+public enum SocialType {
+    KAKAO
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/repository/MemberRepository.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/repository/MemberRepository.java
@@ -1,0 +1,17 @@
+package swyg.vitalroutes.member.repository;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import swyg.vitalroutes.member.domain.Member;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberRepository {
+    private final EntityManager em;
+
+    // Optional 처리 필요
+    public Member findById(Long memberId) {
+        return em.find(Member.class, memberId);
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/post/controller/PostController.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/post/controller/PostController.java
@@ -1,0 +1,63 @@
+package swyg.vitalroutes.post.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import swyg.vitalroutes.common.dto.ApiResponseDto;
+import swyg.vitalroutes.common.exception.FileNotEnoughException;
+import swyg.vitalroutes.common.exception.InputViolateException;
+import swyg.vitalroutes.post.domain.Post;
+import swyg.vitalroutes.post.dto.PostRequestDto;
+import swyg.vitalroutes.post.dto.PostResponseDto;
+import swyg.vitalroutes.post.service.PostService;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class PostController {
+    private final PostService postService;
+
+    @GetMapping("/post/{postId}")
+    public ApiResponseDto<?> findPost(@PathVariable Long postId) {
+        Post post = postService.findPost(postId);
+        PostResponseDto postResponseDto = new PostResponseDto(post);
+        return new ApiResponseDto<>(postResponseDto);
+    }
+
+    @GetMapping("/post")
+    public ApiResponseDto<?> findAllPost() {
+        List<PostResponseDto> list = postService.findAllPost().stream().map(PostResponseDto::new).toList();
+        return new ApiResponseDto<>(list);
+    }
+
+    @PostMapping("/post/add")
+    public ApiResponseDto<?> registerPost(@Valid PostRequestDto postRequestDto, BindingResult bindingResult) {
+
+        if (bindingResult.hasErrors()) {
+            throw new InputViolateException(bindingResult.getFieldError().getDefaultMessage());
+        }
+
+        log.info("postRequestDto = {}", postRequestDto);
+
+        MultipartFile titleImg = postRequestDto.getTitleImg();
+        log.info("titleImg = {}", titleImg);
+
+        List<MultipartFile> files = postRequestDto.getFiles();
+        if (files.size() < 2) {
+            throw new FileNotEnoughException("파일은 두 개 이상 등록해야 합니다");
+        }
+        log.info("files = {}", files);
+
+        Long registeredId = postService.registerPost(postRequestDto);
+
+        return new ApiResponseDto<>(registeredId);
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/post/domain/ChallengeType.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/post/domain/ChallengeType.java
@@ -1,0 +1,5 @@
+package swyg.vitalroutes.post.domain;
+
+public enum ChallengeType {
+    WALK, BICYCLE
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/post/domain/Post.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/post/domain/Post.java
@@ -1,0 +1,74 @@
+package swyg.vitalroutes.post.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import swyg.vitalroutes.Image.domain.Image;
+import swyg.vitalroutes.hashtag.domain.PostMappingTag;
+import swyg.vitalroutes.member.domain.Member;
+import swyg.vitalroutes.post.dto.PostRequestDto;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long postId;
+
+    private String title;
+    @Column(columnDefinition = "TEXT")
+    private String content;
+    @Enumerated(EnumType.STRING)
+    private ChallengeType type;
+
+    private LocalDateTime time;
+    private long viewCnt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<PostMappingTag> tagList = new ArrayList<>();
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "image_id")
+    private Image image;
+
+    // PostMappingTag 에 POST 참조를 넣어줌
+    private void setPostInPostMappingTag(PostMappingTag postMappingTag) {
+        postMappingTag.setPost(this);
+    }
+
+    private void setPostInImage(Image image) {
+        image.setPost(this);
+    }
+
+    public static Post createPost(PostRequestDto postRequestDto, Member member, List<PostMappingTag> postMappingTags, Image image) {
+        Post post = new Post();
+        post.setTitle(postRequestDto.getTitle());
+        post.setContent(postRequestDto.getContent());
+        post.setType(ChallengeType.valueOf(postRequestDto.getType()));
+        post.setTime(LocalDateTime.now());
+        post.setViewCnt(0L);
+        // 연관관계 세팅
+        post.setMember(member);
+
+        post.setImage(image);
+        post.setPostInImage(image);
+
+        for (PostMappingTag mappingTag : postMappingTags) {
+            post.setPostInPostMappingTag(mappingTag);
+            post.getTagList().add(mappingTag);
+        }
+        return post;
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/post/dto/PostRequestDto.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/post/dto/PostRequestDto.java
@@ -1,0 +1,26 @@
+package swyg.vitalroutes.post.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Data
+public class PostRequestDto {
+    private Long postId;
+    private Long memberId;
+    @NotBlank(message = "제목은 24자 이내로 작성해주세요")
+    @Size(min = 1, max = 24, message = "제목은 1자 이상 24자 이내만 입력 가능합니다")
+    private String title;
+    @NotBlank(message = "게시글 내용은 2000자 이내로 작성해주세요")
+    @Size(min = 1, max = 2000, message = "게시글 내용은 2000자 이내로 작성해주세요")
+    private String content;
+    @NotBlank(message = "이동 방법을 선택해주세요")
+    private String type;
+    private List<String> tags;
+
+    private MultipartFile titleImg;
+    private List<MultipartFile> files;
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/post/dto/PostResponseDto.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/post/dto/PostResponseDto.java
@@ -1,0 +1,53 @@
+package swyg.vitalroutes.post.dto;
+
+import lombok.Data;
+import swyg.vitalroutes.Image.domain.Location;
+import swyg.vitalroutes.post.domain.ChallengeType;
+import swyg.vitalroutes.post.domain.Post;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class PostResponseDto {
+    private Long postId;
+    private String memberName;
+    private String title;
+    private String content;
+    private ChallengeType type;
+    private long viewCnt;
+    private List<Map<String, String>> tagList = new ArrayList<>();
+    private String titleImg;
+    private List<Map<String, String>> images = new ArrayList<>();
+
+    public PostResponseDto(Post post) {
+        postId = post.getPostId();
+        title = post.getTitle();
+        content = post.getContent();
+        type = post.getType();
+        viewCnt = post.getViewCnt();
+
+        memberName = post.getMember().getName();
+        post.getTagList().forEach(tag -> {
+            this.tagList.add(Map.of(tag.getHashTag().getTagId(), tag.getHashTag().getTagName()));
+        });
+
+        titleImg = post.getImage().getTitleImg();
+        for (Location location : post.getImage().getLocations()) {
+            images.add(createLocationMap(location));
+        }
+    }
+
+    public Map<String, String> createLocationMap(Location location) {
+        Map<String, String> map = new HashMap<>();
+        if (location != null) {
+            map.put("sequence", String.valueOf(location.getSequence()));
+            map.put("imageUrl", location.getFileName());
+            map.put("latitude", location.getLatitude());
+            map.put("longitude", location.getLongitude());
+        }
+        return map;
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/post/repository/PostRepository.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/post/repository/PostRepository.java
@@ -1,0 +1,39 @@
+package swyg.vitalroutes.post.repository;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import swyg.vitalroutes.post.domain.Post;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PostRepository {
+
+    private final EntityManager em;
+
+    public Long registerPost(Post post) {
+        em.persist(post);
+        return post.getPostId();
+    }
+
+    public Post findById(Long postId) {
+        return em.createQuery(
+                        "select p from Post p " +
+                                "join fetch p.member " +
+                                "join fetch p.image " +
+                                "where p.id = :postId", Post.class)
+                .setParameter("postId", postId)
+                .getSingleResult();
+    }
+
+    public List<Post> findAll() {
+        return em.createQuery(
+                        "select p from Post p " +
+                                "join fetch p.member " +
+                                "join fetch p.image", Post.class)
+                .getResultList();
+    }
+
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/post/service/PostService.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/post/service/PostService.java
@@ -1,0 +1,77 @@
+package swyg.vitalroutes.post.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import swyg.vitalroutes.Image.domain.Image;
+import swyg.vitalroutes.Image.domain.Location;
+import swyg.vitalroutes.common.file.FileUtils;
+import swyg.vitalroutes.hashtag.domain.PostMappingTag;
+import swyg.vitalroutes.hashtag.repository.HashTagRepository;
+import swyg.vitalroutes.member.domain.Member;
+import swyg.vitalroutes.member.repository.MemberRepository;
+import swyg.vitalroutes.post.domain.Post;
+import swyg.vitalroutes.post.dto.PostRequestDto;
+import swyg.vitalroutes.post.repository.PostRepository;
+import swyg.vitalroutes.s3.S3UploadService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+    private final HashTagRepository hashTagRepository;
+    private final S3UploadService s3UploadService;
+
+    public Long registerPost(PostRequestDto postRequestDto) {
+        Member member = memberRepository.findById(postRequestDto.getMemberId());
+        // PostMappingTag Entity 생성
+        List<PostMappingTag> tagList = new ArrayList<>();
+        for(String tag : postRequestDto.getTags()) {
+            tagList.add(PostMappingTag.createPostMapTag(hashTagRepository.findTag(tag)));
+        }
+        /**
+         * Image Entity 생성
+         * 1. S3UploadService 를 호출해서 파일을 저장하고 URL 을 반환받는다
+         * 2. FileUtils 호출해서 위도, 경도를 가진 String[] 을 반환받는다
+         * 3. String[] 으로 Location 을 생성한다
+         * 4. Image 를 생성해서 Location 을 저장한다
+         */
+        MultipartFile titleImg = postRequestDto.getTitleImg();
+        String titleImgUrl = "title image url";
+        //String titleImgUrl = s3UploadService.saveFile(titleImg);
+
+        List<Location> locations = new ArrayList<>();
+        List<MultipartFile> files = postRequestDto.getFiles();
+        int seq = 0;
+        for (MultipartFile file : files) {
+            String fileName = "file image url";
+            // String fileName = s3UploadService.saveFile(file);
+            String[] locationInfo = FileUtils.getLocationInfo(file);
+            locations.add(Location.createLocation(++seq, fileName, locationInfo));
+        }
+        Image image = Image.crateImage(titleImgUrl, locations);
+        
+        // POST Entity 생성
+        Post post = Post.createPost(postRequestDto, member, tagList, image);
+        return postRepository.registerPost(post);
+    }
+
+    @Transactional(readOnly = true)
+    public Post findPost(Long postId) {
+        return postRepository.findById(postId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Post> findAllPost() {
+        return postRepository.findAll();
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/s3/S3Config.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/s3/S3Config.java
@@ -4,7 +4,7 @@ import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import lombok.Value;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/vitalroutes/src/main/java/swyg/vitalroutes/s3/S3UploadService.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/s3/S3UploadService.java
@@ -3,7 +3,7 @@ package swyg.vitalroutes.s3;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import lombok.RequiredArgsConstructor;
-import lombok.Value;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.UrlResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -28,7 +28,9 @@ public class S3UploadService {
         metadata.setContentLength(multipartFile.getSize());
         metadata.setContentType(multipartFile.getContentType());
 
+        // 파일 저장 메서드
         amazonS3.putObject(bucket, originalFilename, multipartFile.getInputStream(), metadata);
+        // getUrl : 파일이 저장된 URL 을 return, 해당 URL 로 이동 시 파일이 오픈
         return amazonS3.getUrl(bucket, originalFilename).toString();
     }
 
@@ -38,7 +40,7 @@ public class S3UploadService {
 
         String contentDisposition = "attachment; filename=\"" +  originalFilename + "\"";
 
-        // header에 CONTENT_DISPOSITION 설정을 통해 클릭 시 다운로드 진행
+        // header 에 CONTENT_DISPOSITION 설정을 통해 클릭 시 다운로드 진행
         return ResponseEntity.ok()
                 .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition)
                 .body(urlResource);

--- a/vitalroutes/src/main/resources/application.properties
+++ b/vitalroutes/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.format_sql=true
+#spring.jpa.properties.hibernate.default_batch_fetch_size=100
+
+logging.level.org.hibernate.SQL=debug
+
+spring.profiles.include=aws-s3, mysql
+
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=50MB


### PR DESCRIPTION
### 게시글 등록 및 조회 API 구현
 - 게시글과 관련된 이미지, 위치, 태그, 회원 엔티티 함께 생성
 - S3 업로드는 현재 주석 처리
 - `build.gradle` 업로드 X

### 관련 사항
- 게시글 등록 및 조회 공통 구현으로 인한 업로드
- `feature/Post` 브랜치에 구현 내용 반영

### 요청 API
- Headers
   - Content-Type : multipart/form-data
- Body
   - memberId : text
   - title : text
   - type : text ( WALK, BICYCLE )
   - tags : text
   - titleImg :  file ( 대표 이미지 )
   - files : file ( spot 이미지 )