### PR TITLE
feat: 회원가입 API 구현

### DIFF
--- a/vitalroutes/build.gradle
+++ b/vitalroutes/build.gradle
@@ -23,12 +23,18 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	//implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+	//implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE' // aws s3 라이브러리 추가
+
+	implementation 'org.springframework.boot:spring-boot-starter-validation'	// validation
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'	// sql 문 내부에 파라미터 넣어서 출력
+	implementation 'com.drewnoakes:metadata-extractor:2.18.0'	// 사진에서 위도, 경도 추출 라이브러리
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'	// Swagger SpringDoc
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/config/SwaggerConfig.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/config/SwaggerConfig.java
@@ -1,0 +1,17 @@
+package swyg.vitalroutes.common.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI().info(new Info()
+                .title("VitalRoutes")
+                .description("VitalRoutes Api 명세서")
+                .version("1.0.0"));
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/controller/ApiExceptionController.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/controller/ApiExceptionController.java
@@ -1,0 +1,17 @@
+package swyg.vitalroutes.common.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import swyg.vitalroutes.common.exception.MemberSignUpException;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class ApiExceptionController {
+    @ExceptionHandler(MemberSignUpException.class)
+    public ResponseEntity<?> memberSignUpEx(MemberSignUpException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", exception.getMessage()));
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/MemberSignUpException.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/MemberSignUpException.java
@@ -1,0 +1,7 @@
+package swyg.vitalroutes.common.exception;
+
+public class MemberSignUpException extends RuntimeException{
+    public MemberSignUpException(String message) {
+        super(message);
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/controller/MemberController.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/controller/MemberController.java
@@ -1,0 +1,84 @@
+package swyg.vitalroutes.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import swyg.vitalroutes.common.exception.MemberSignUpException;
+import swyg.vitalroutes.member.domain.MemberSaveDTO;
+import swyg.vitalroutes.member.service.MemberService;
+
+import java.util.Map;
+
+@Tag(name = "Member API Controller", description = "Member 회원가입, 로그인을 기능을 제공하는 Controller")
+@Slf4j
+@RequestMapping("/member")
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @Operation(description = "{'nickname' : 'userNickName'} 형태로 전달필요", summary = "닉네임 중복 확인")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "닉네임 인증 완료",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400",
+                    description = "닉네임 전달 오류 or 이미 존재하는 닉네임 ( 예외 메세지에 표시됨 )",
+                    content = @Content(mediaType = "application/json"))
+    })
+    @PostMapping("/duplicateCheck")
+    public ResponseEntity<?> duplicateCheck(@RequestBody Map<String, String> map) {
+        String nickname = map.get("nickname");
+        if (nickname == null) {
+            throw new MemberSignUpException("닉네임이 전달되지 않았습니다.");
+        }
+        log.info("nickname = {}", nickname);
+        if (memberService.duplicateNicknameCheck(map.get("nickname"))) {
+            throw new MemberSignUpException("이미 존재하는 닉네임입니다.");
+        }
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("success", "닉네임 인증이 완료되었습니다"));
+    }
+
+    @Operation(summary = "회원가입")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "회원가입 성공",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400",
+                    description = "닉네임 중복 확인 필요",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "500",
+                    description = "회원가입 중 서버 내부 오류 발생",
+                    content = @Content(mediaType = "application/json"))
+    })
+    @PostMapping("/signUp")
+    public ResponseEntity<?> signUp(@Valid @RequestBody MemberSaveDTO memberDTO, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            throw new MemberSignUpException(bindingResult.getFieldError().getDefaultMessage());
+        }
+
+        if (!memberDTO.getIsChecked()) {
+            throw new MemberSignUpException("닉네임 중복 확인이 필요합니다");
+        }
+
+        try {
+            memberService.saveMember(memberDTO);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("회원가입 중 오류가 발생하였습니다");
+        }
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("success", "회원가입이 완료되었습니다"));
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/Member.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/Member.java
@@ -1,0 +1,36 @@
+package swyg.vitalroutes.member.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Member {
+    /**
+     * country 제거
+     * nickname 추가
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long memberId;
+    private String profile;
+    private String name;
+    @Column(unique = true)
+    private String nickname;
+    @Column(unique = true)
+    private String email;
+    private String password;
+    private String socialId;
+
+    @Enumerated(EnumType.STRING)
+    private SocialType socialType;
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberSaveDTO.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberSaveDTO.java
@@ -1,0 +1,38 @@
+package swyg.vitalroutes.member.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Schema(description = "회원가입 시 사용")
+@Data
+public class MemberSaveDTO {
+    /**
+     * 닉네임 규칙 : 특수문자 없이 최소 3자에서 최대 16자 사이로 제한
+     * 비밀번호 규칙 : 최소 8자 이상이며, 대문자, 소문자, 숫자 중 최소 2종류를 포함
+     */
+
+    @NotBlank(message = "이름은 필수입력값 입니다")
+    private String name;
+
+    @NotBlank(message = "닉네임은 필수입력값 입니다")
+    @Size(min = 3, max = 16, message = "닉네임은 3자에서 16자 사이로 입력 가능합니다")
+    @Pattern(regexp = "[0-9|a-z|A-Z|ㄱ-ㅎ|ㅏ-ㅣ|가-힝|(|)|.|-]*", message = "특수문자는 입력이 불가능합니다")
+    @Schema(description = "3자에서 16자 사이로 입력 가능")
+    private String nickname;
+
+    @NotBlank(message = "이메일은 필수입력값 입니다")
+    @Email(message = "올바르지 않은 이메일 형식입니다")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입력값 입니다")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,}$", message = "비밀번호는 대문자, 소문자, 숫자를 포함한 최소 8자 이상이어야 합니다")
+    @Schema(description = "대문자, 소문자, 숫자를 포함한 최소 8자 이상")
+    private String password;
+
+    @Schema(description = "닉네임 중복 확인 후, 해당 필드를 true 로 보내주어야 함")
+    private Boolean isChecked = false;
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/SocialType.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/SocialType.java
@@ -1,0 +1,5 @@
+package swyg.vitalroutes.member.domain;
+
+public enum SocialType {
+    KAKAO
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/repository/MemberRepository.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/repository/MemberRepository.java
@@ -1,0 +1,17 @@
+package swyg.vitalroutes.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import swyg.vitalroutes.member.domain.Member;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    @Query("select m from Member m where m.nickname = :nickname")
+    Optional<Member> findByNickname(@Param("nickname") String nickname);
+    
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/service/MemberService.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/service/MemberService.java
@@ -1,0 +1,37 @@
+package swyg.vitalroutes.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import swyg.vitalroutes.member.domain.Member;
+import swyg.vitalroutes.member.domain.MemberSaveDTO;
+import swyg.vitalroutes.member.repository.MemberRepository;
+
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    // 닉네임이 중복이면 true
+    public boolean duplicateNicknameCheck(String nickname) {
+        Optional<Member> byNickname = memberRepository.findByNickname(nickname);
+        return byNickname.isPresent();
+    }
+
+    public Member saveMember(MemberSaveDTO memberDTO) {
+        Member member = Member.builder()
+                .name(memberDTO.getName())
+                .nickname(memberDTO.getNickname())
+                .email(memberDTO.getEmail())
+                .password(passwordEncoder.encode(memberDTO.getPassword()))
+                .build();
+        return memberRepository.save(member);
+    }
+
+}


### PR DESCRIPTION
### 회원가입 API 구현
- 닉네임 중복 확인
- 비밀번호 규칙 확인
- 패스워드 암호화
- 회원가입 완료 후 성공 응답 반환
- Swagger 추가하여 API 상세 내용 작성

### 변경 사항
- Member 테이블 country 필드 제거
- Member 테이블 nickname 필드 추가
- build.gradle 에 Swagger 및 기타 라이브러리 추가

resolves #3 