### PR TITLE
카카오 소셜 로그인 및 API 스펙 통일

### DIFF
--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/controller/ApiExceptionController.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/controller/ApiExceptionController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import swyg.vitalroutes.common.exception.JwtTokenException;
+import swyg.vitalroutes.common.exception.KakaoLoginException;
 import swyg.vitalroutes.common.exception.MemberSignUpException;
 
 import java.util.Map;
@@ -18,6 +19,11 @@ public class ApiExceptionController {
 
     @ExceptionHandler(JwtTokenException.class)
     public ResponseEntity<?> jwtTokenEx(JwtTokenException exception) {
+        return ResponseEntity.status(exception.getStatusCode()).body(Map.of("error", exception.getMessage()));
+    }
+
+    @ExceptionHandler(KakaoLoginException.class)
+    public ResponseEntity<?> kakaoLoginEx(KakaoLoginException exception) {
         return ResponseEntity.status(exception.getStatusCode()).body(Map.of("error", exception.getMessage()));
     }
 }

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/controller/ApiExceptionController.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/controller/ApiExceptionController.java
@@ -7,23 +7,24 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import swyg.vitalroutes.common.exception.JwtTokenException;
 import swyg.vitalroutes.common.exception.KakaoLoginException;
 import swyg.vitalroutes.common.exception.MemberSignUpException;
+import swyg.vitalroutes.common.response.ApiResponseDTO;
 
 import java.util.Map;
 
 @RestControllerAdvice
 public class ApiExceptionController {
     @ExceptionHandler(MemberSignUpException.class)
-    public ResponseEntity<?> memberSignUpEx(MemberSignUpException exception) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", exception.getMessage()));
+    public ApiResponseDTO<?> memberSignUpEx(MemberSignUpException exception) {
+        return new ApiResponseDTO<>(exception.getStatus(), exception.getType(), exception.getMessage(), null);
     }
 
     @ExceptionHandler(JwtTokenException.class)
-    public ResponseEntity<?> jwtTokenEx(JwtTokenException exception) {
-        return ResponseEntity.status(exception.getStatusCode()).body(Map.of("error", exception.getMessage()));
+    public ApiResponseDTO<?> jwtTokenEx(JwtTokenException exception) {
+        return new ApiResponseDTO<>(exception.getStatus(), exception.getType(), exception.getMessage(), null);
     }
 
     @ExceptionHandler(KakaoLoginException.class)
-    public ResponseEntity<?> kakaoLoginEx(KakaoLoginException exception) {
-        return ResponseEntity.status(exception.getStatusCode()).body(Map.of("error", exception.getMessage()));
+    public ApiResponseDTO<?> kakaoLoginEx(KakaoLoginException exception) {
+        return new ApiResponseDTO<>(exception.getStatus(), exception.getType(), exception.getMessage(), null);
     }
 }

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/JwtTokenException.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/JwtTokenException.java
@@ -2,14 +2,17 @@ package swyg.vitalroutes.common.exception;
 
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
+import swyg.vitalroutes.common.response.ResponseType;
 
 @Getter
 public class JwtTokenException extends RuntimeException {
 
-    public int statusCode;
+    public HttpStatus status;
+    public ResponseType type;
 
-    public JwtTokenException(int statusCode, String message) {
+    public JwtTokenException(HttpStatus status, ResponseType type, String message) {
         super(message);
-        this.statusCode = statusCode;
+        this.status = status;
+        this.type = type;
     }
 }

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/KakaoLoginException.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/KakaoLoginException.java
@@ -1,13 +1,17 @@
 package swyg.vitalroutes.common.exception;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import swyg.vitalroutes.common.response.ResponseType;
 
 @Getter
 public class KakaoLoginException extends RuntimeException{
-    public int statusCode;
+    public HttpStatus status;
+    public ResponseType type;
 
-    public KakaoLoginException(int statusCode, String message) {
+    public KakaoLoginException(HttpStatus status, ResponseType type, String message) {
         super(message);
-        this.statusCode = statusCode;
+        this.status = status;
+        this.type = type;
     }
 }

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/KakaoLoginException.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/KakaoLoginException.java
@@ -1,0 +1,13 @@
+package swyg.vitalroutes.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoLoginException extends RuntimeException{
+    public int statusCode;
+
+    public KakaoLoginException(int statusCode, String message) {
+        super(message);
+        this.statusCode = statusCode;
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/MemberSignUpException.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/MemberSignUpException.java
@@ -1,7 +1,17 @@
 package swyg.vitalroutes.common.exception;
 
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import swyg.vitalroutes.common.response.ResponseType;
+
+@Getter
 public class MemberSignUpException extends RuntimeException{
-    public MemberSignUpException(String message) {
+    public HttpStatus status;
+    public ResponseType type;
+
+    public MemberSignUpException(HttpStatus status, ResponseType type, String message) {
         super(message);
+        this.status = status;
+        this.type = type;
     }
 }

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/response/ApiResponseDTO.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/response/ApiResponseDTO.java
@@ -1,0 +1,14 @@
+package swyg.vitalroutes.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.http.HttpStatus;
+
+@Data
+@AllArgsConstructor
+public class ApiResponseDTO<T> {
+    private HttpStatus status;
+    private ResponseType type;
+    private String message;
+    private T data;
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/response/ApiResponseDTO.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/response/ApiResponseDTO.java
@@ -1,14 +1,19 @@
 package swyg.vitalroutes.common.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.springframework.http.HttpStatus;
 
+@Schema(description = "API 응답 스펙")
 @Data
 @AllArgsConstructor
 public class ApiResponseDTO<T> {
+    @Schema(description = "Http Status ( 숫자 X )")
     private HttpStatus status;
+    @Schema(description = "임의로 정의한 type 으로 ENUM 타입으로 정의")
     private ResponseType type;
     private String message;
+    @Schema(description = "서버에서 전달되는 데이터를 data 에 json 형식으로 담아서 전달")
     private T data;
 }

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/response/ResponseType.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/response/ResponseType.java
@@ -1,0 +1,5 @@
+package swyg.vitalroutes.common.response;
+
+public enum ResponseType {
+    SUCCESS, ONGOING, FAIL, ERROR
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/controller/MemberController.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/controller/MemberController.java
@@ -19,12 +19,12 @@ import org.springframework.web.bind.annotation.RestController;
 import swyg.vitalroutes.common.exception.MemberSignUpException;
 import swyg.vitalroutes.member.domain.MemberSaveDTO;
 import swyg.vitalroutes.member.service.MemberService;
+import swyg.vitalroutes.security.domain.SocialMemberDTO;
 
 import java.util.Map;
 
 @Tag(name = "Member API Controller", description = "Member 회원가입, 로그인을 기능을 제공하는 Controller")
 @Slf4j
-@RequestMapping("/member")
 @RestController
 @RequiredArgsConstructor
 public class MemberController {
@@ -40,7 +40,7 @@ public class MemberController {
                     description = "닉네임 전달 오류 or 이미 존재하는 닉네임 ( 예외 메세지에 표시됨 )",
                     content = @Content(mediaType = "application/json"))
     })
-    @PostMapping("/duplicateCheck")
+    @PostMapping("/member/duplicateCheck")
     public ResponseEntity<?> duplicateCheck(@RequestBody Map<String, String> map) {
         String nickname = map.get("nickname");
         if (nickname == null) {
@@ -65,7 +65,7 @@ public class MemberController {
                     description = "회원가입 중 서버 내부 오류 발생",
                     content = @Content(mediaType = "application/json"))
     })
-    @PostMapping("/signUp")
+    @PostMapping("/member/signUp")
     public ResponseEntity<?> signUp(@Valid @RequestBody MemberSaveDTO memberDTO, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             throw new MemberSignUpException(bindingResult.getFieldError().getDefaultMessage());
@@ -80,7 +80,41 @@ public class MemberController {
         } catch (DataIntegrityViolationException e) {
             throw new MemberSignUpException("중복되는 닉네임 혹은 이메일이 존재합니다");
         } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("회원가입 중 오류가 발생하였습니다");
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "회원가입 중 오류가 발생하였습니다"));
+        }
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("success", "회원가입이 완료되었습니다"));
+    }
+
+    @Operation(summary = "소셜 회원 가입")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "회원가입 성공",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400",
+                    description = "닉네임 중복 확인 필요",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "500",
+                    description = "회원가입 중 서버 내부 오류 발생",
+                    content = @Content(mediaType = "application/json"))
+    })
+    @PostMapping("/oauth2/signUp")
+    public ResponseEntity<?> socialSignUp(@Valid @RequestBody SocialMemberDTO memberDTO, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            throw new MemberSignUpException(bindingResult.getFieldError().getDefaultMessage());
+        }
+
+        if (!memberDTO.getIsChecked()) {
+            throw new MemberSignUpException("닉네임 중복 확인이 필요합니다");
+        }
+
+        try {
+            memberService.saveSocialMember(memberDTO);
+        } catch (DataIntegrityViolationException e) {
+            throw new MemberSignUpException("중복되는 닉네임이 존재합니다");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "회원가입 중 오류가 발생하였습니다"));
         }
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("success", "회원가입이 완료되었습니다"));
     }

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/controller/MemberController.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/controller/MemberController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import swyg.vitalroutes.common.exception.MemberSignUpException;
 import swyg.vitalroutes.common.response.ApiResponseDTO;
+import swyg.vitalroutes.member.domain.MemberNicknameDTO;
 import swyg.vitalroutes.member.domain.MemberSaveDTO;
 import swyg.vitalroutes.member.service.MemberService;
 import swyg.vitalroutes.security.domain.SocialMemberDTO;
@@ -43,13 +44,13 @@ public class MemberController {
                     content = @Content(mediaType = "application/json"))
     })
     @PostMapping("/member/duplicateCheck")
-    public ApiResponseDTO<?> duplicateCheck(@RequestBody Map<String, String> map) {
-        String nickname = map.get("nickname");
+    public ApiResponseDTO<?> duplicateCheck(@RequestBody MemberNicknameDTO dto) {
+        String nickname = dto.getNickname();
         if (nickname == null) {
             return new ApiResponseDTO<>(BAD_REQUEST, FAIL, "닉네임이 전달되지 않았습니다", null);
         }
         log.info("nickname = {}", nickname);
-        if (memberService.duplicateNicknameCheck(map.get("nickname"))) {
+        if (memberService.duplicateNicknameCheck(dto.getNickname())) {
             return new ApiResponseDTO<>(BAD_REQUEST, FAIL, "이미 존재하는 닉네임입니다", null);
         }
         return new ApiResponseDTO<>(OK, SUCCESS, "닉네임 인증이 완료되었습니다", null);

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/Member.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/Member.java
@@ -42,6 +42,8 @@ public class Member {
         dataMap.put("name", name);
         dataMap.put("nickname", nickname);
         dataMap.put("email", email);
+        dataMap.put("socialId", socialId);
+        dataMap.put("socialType", socialType);
         return dataMap;
     }
 }

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberNicknameDTO.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberNicknameDTO.java
@@ -1,8 +1,9 @@
 package swyg.vitalroutes.member.domain;
 
-import lombok.AllArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+@Schema(description = "Body 에 담긴 Nickname 을 담는 DTO")
 @Data
 public class MemberNicknameDTO {
     private String nickname;

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberNicknameDTO.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberNicknameDTO.java
@@ -1,0 +1,9 @@
+package swyg.vitalroutes.member.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+public class MemberNicknameDTO {
+    private String nickname;
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/repository/MemberRepository.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/repository/MemberRepository.java
@@ -5,7 +5,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import swyg.vitalroutes.member.domain.Member;
+import swyg.vitalroutes.member.domain.SocialType;
 
+import javax.swing.text.html.Option;
 import java.util.Optional;
 
 @Repository
@@ -16,5 +18,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("select m from Member m where m.email = :email")
     Optional<Member> findByEmail(@Param("email") String email);
+
+    @Query("select m from Member m where m.socialId = :socialId and m.socialType = :socialType")
+    Optional<Member> findBySocialIdAndSocialType(@Param("socialId") String socialId,
+                                                 @Param("socialType") SocialType socialType);
+
     
 }

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/service/MemberService.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/service/MemberService.java
@@ -6,7 +6,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import swyg.vitalroutes.member.domain.Member;
 import swyg.vitalroutes.member.domain.MemberSaveDTO;
+import swyg.vitalroutes.member.domain.SocialType;
 import swyg.vitalroutes.member.repository.MemberRepository;
+import swyg.vitalroutes.security.domain.SocialMemberDTO;
 
 import java.util.Optional;
 
@@ -30,6 +32,16 @@ public class MemberService {
                 .nickname(memberDTO.getNickname())
                 .email(memberDTO.getEmail())
                 .password(passwordEncoder.encode(memberDTO.getPassword()))
+                .build();
+        return memberRepository.save(member);
+    }
+
+    public Member saveSocialMember(SocialMemberDTO memberDTO) {
+        Member member = Member.builder()
+                .name(memberDTO.getName())
+                .nickname(memberDTO.getNickname())
+                .socialId(memberDTO.getSocialId())
+                .socialType(SocialType.valueOf(memberDTO.getSocialType()))
                 .build();
         return memberRepository.save(member);
     }

--- a/vitalroutes/src/main/java/swyg/vitalroutes/security/controller/KakaoLoginController.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/security/controller/KakaoLoginController.java
@@ -48,8 +48,7 @@ public class KakaoLoginController {
 
     @Operation(description = "카카오 로그인 페이지로 이동하게 리다이렉트 시킨다", summary = "카카오 로그인 페이지 호출")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "301",
-                    description = "카카오 로그인 화면으로 리다이렉트")}
+            @ApiResponse(description = "카카오 로그인 화면으로 리다이렉트")}
     )
     @GetMapping("/oauth2/kakao")
     public void kakaoRedirect(HttpServletResponse response) throws IOException {
@@ -62,17 +61,17 @@ public class KakaoLoginController {
         response.sendRedirect(uriString);
     }
 
-    @Operation(description = "카카오 로그인 페이지로 이동하게 리다이렉트 시킨다", summary = "카카오 로그인 페이지 호출")
+    @Operation(description = "카카오 로그인 후 전달 받은 인가코드를 전달한다", summary = "카카오 인가코드 전달 및 소셜 로그인 진행")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200",
-                    description = "로그인 성공, 일반 로그인 성공과 동일한 응답",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "202",
-                    description = "최초 로그인 시 회원가입을 위해 필요한 정보 전달, name, socialId, socialType 데이터만 담겨있음",
+            @ApiResponse(responseCode = "OK SUCCESS(type)",
+                    description = "로그인 성공",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponseDTO.class))),
+            @ApiResponse(responseCode = "OK ONGOING(type)",
+                    description = "최초 로그인 시 회원가입을 위해 필요한 정보 전달, API 응답 스펙의 data 에 들어가며, 아래 정보들 모두를 회원가입 API 로 전달해야함",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = SocialMemberDTO.class)))
     })
     @Parameters(value = {
-            @Parameter(required = true, description = "카카오 로그인 후 받게 되는 인가코드를 전달해야함")
+            @Parameter(name = "code", required = true, description = "카카오 로그인 후 받게 되는 인가코드를 전달해야함")
     })
     @GetMapping("/oauth2/kakao/login")
     public ApiResponseDTO<?> kakaoLogin(@RequestParam("code") String code) {

--- a/vitalroutes/src/main/java/swyg/vitalroutes/security/controller/KakaoLoginController.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/security/controller/KakaoLoginController.java
@@ -1,0 +1,94 @@
+package swyg.vitalroutes.security.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+import swyg.vitalroutes.member.domain.Member;
+import swyg.vitalroutes.member.domain.SocialType;
+import swyg.vitalroutes.security.domain.SocialMemberDTO;
+import swyg.vitalroutes.security.service.KakaoLoginService;
+import swyg.vitalroutes.security.utils.JwtConstants;
+import swyg.vitalroutes.security.utils.JwtTokenProvider;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+@Tag(name = "Kakao Login API Controller", description = "카카오 소셜 로그인을 위한 controller ")
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class KakaoLoginController {
+    @Value("${kakao.login.client-id}")
+    private String restAPiKey;
+
+    @Value("${kakao.login.redirect-uri}")
+    private String redirectURI;
+
+    private final KakaoLoginService kakaoLoginService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Operation(description = "카카오 로그인 페이지로 이동하게 리다이렉트 시킨다", summary = "카카오 로그인 페이지 호출")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "301",
+                    description = "카카오 로그인 화면으로 리다이렉트")}
+    )
+    @GetMapping("/oauth2/kakao")
+    public void kakaoRedirect(HttpServletResponse response) throws IOException {
+        String uriString = UriComponentsBuilder
+                .fromUriString("https://kauth.kakao.com/oauth/authorize")
+                .queryParam("response_type", "code")
+                .queryParam("client_id", restAPiKey)
+                .queryParam("redirect_uri", redirectURI)
+                .toUriString();
+        response.sendRedirect(uriString);
+    }
+
+    @Operation(description = "카카오 로그인 페이지로 이동하게 리다이렉트 시킨다", summary = "카카오 로그인 페이지 호출")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "로그인 성공, 일반 로그인 성공과 동일한 응답",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "202",
+                    description = "최초 로그인 시 회원가입을 위해 필요한 정보 전달, name, socialId, socialType 데이터만 담겨있음",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = SocialMemberDTO.class)))
+    })
+    @Parameters(value = {
+            @Parameter(required = true, description = "카카오 로그인 후 받게 되는 인가코드를 전달해야함")
+    })
+    @GetMapping("/oauth2/kakao/login")
+    public ResponseEntity<?> kakaoLogin(@RequestParam("code") String code) {
+        String[] userInfo = kakaoLoginService.kakaoLogin(code);
+        Optional<Member> optionalMember = kakaoLoginService.findMember(userInfo[0], SocialType.KAKAO);
+        if (optionalMember.isPresent()) {
+            log.info("----------------------- 존재하는 소셜 회원 -----------------------");
+            // 사용자가 있는 경우, 일반 로그인 성공과 동일하게 처리( 토큰 발급 )
+            Member member = optionalMember.get();
+            Map<String, Object> claims = member.getClaims();
+            claims.put("accessToken", jwtTokenProvider.generateToken(claims, JwtConstants.ACCESS_EXP_TIME));
+            claims.put("refreshToken", jwtTokenProvider.generateToken(claims, JwtConstants.REFRESH_EXP_TIME));
+            return ResponseEntity.status(HttpStatus.OK).body(claims);
+        }
+        log.info("----------------------- 회원가입 필요 -----------------------");
+        SocialMemberDTO socialMemberDTO = new SocialMemberDTO();
+        socialMemberDTO.setName(userInfo[1]);
+        socialMemberDTO.setSocialId(userInfo[0]);
+        socialMemberDTO.setSocialType("KAKAO");
+        return ResponseEntity.status(HttpStatus.OK).body(socialMemberDTO);
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/security/controller/TokenRefreshController.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/security/controller/TokenRefreshController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import swyg.vitalroutes.common.exception.JwtTokenException;
 import swyg.vitalroutes.common.response.ApiResponseDTO;
+import swyg.vitalroutes.security.domain.RefreshTokenDTO;
 import swyg.vitalroutes.security.utils.JwtConstants;
 import swyg.vitalroutes.security.utils.JwtTokenProvider;
 
@@ -37,10 +38,10 @@ public class TokenRefreshController {
                     content = @Content(mediaType = "application/json"))
     })
     @PostMapping("/token/refresh")
-    public ApiResponseDTO<?> tokenRefresh(@RequestHeader("Authorization") String authHeader, @RequestBody Map<String, String> body) {
+    public ApiResponseDTO<?> tokenRefresh(@RequestHeader("Authorization") String authHeader, @RequestBody RefreshTokenDTO dto) {
         jwtTokenProvider.checkAuthorizationHeader(authHeader);
         String accessToken = jwtTokenProvider.getTokenFromHeader(authHeader);
-        String refreshToken = body.get("refreshToken");
+        String refreshToken = dto.getRefreshToken();
 
         log.info("refresh Token = {}", refreshToken);
 

--- a/vitalroutes/src/main/java/swyg/vitalroutes/security/controller/TokenRefreshController.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/security/controller/TokenRefreshController.java
@@ -1,20 +1,28 @@
 package swyg.vitalroutes.security.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import swyg.vitalroutes.common.exception.JwtTokenException;
+import swyg.vitalroutes.common.response.ApiResponseDTO;
 import swyg.vitalroutes.security.utils.JwtConstants;
 import swyg.vitalroutes.security.utils.JwtTokenProvider;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.springframework.http.HttpStatus.*;
+import static swyg.vitalroutes.common.response.ResponseType.*;
+
+@Tag(name = "Token Refresh Controller", description = "토큰 갱신을 위한 controller ")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -22,8 +30,14 @@ public class TokenRefreshController {
 
     private final JwtTokenProvider jwtTokenProvider;
 
+    @Operation(description = "{'refreshToken' : 'aaaaaa'} 형태로 전달필요", summary = "Access Token 갱신")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "정상적으로 access token 이 갱신됨",
+                    content = @Content(mediaType = "application/json"))
+    })
     @PostMapping("/token/refresh")
-    public ResponseEntity<?> tokenRefresh(@RequestHeader("Authorization") String authHeader, @RequestBody Map<String, String> body) {
+    public ApiResponseDTO<?> tokenRefresh(@RequestHeader("Authorization") String authHeader, @RequestBody Map<String, String> body) {
         jwtTokenProvider.checkAuthorizationHeader(authHeader);
         String accessToken = jwtTokenProvider.getTokenFromHeader(authHeader);
         String refreshToken = body.get("refreshToken");
@@ -31,7 +45,7 @@ public class TokenRefreshController {
         log.info("refresh Token = {}", refreshToken);
 
         if (refreshToken == null) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", "refresh Token 이 전달되지 않았습니다"));
+            return new ApiResponseDTO<>(BAD_REQUEST, FAIL, "refresh Token 이 전달되지 않았습니다", null);
         }
 
         Map<String, String> res = new HashMap<>();
@@ -42,13 +56,13 @@ public class TokenRefreshController {
                 Map<String, Object> claims = jwtTokenProvider.validateToken(refreshToken);
                 accessToken = jwtTokenProvider.generateToken(claims, JwtConstants.ACCESS_EXP_TIME);
             } catch (JwtTokenException exception) {
-                throw new JwtTokenException(400, "Refresh Token 이 만료되었습니다");
+                return new ApiResponseDTO<>(BAD_REQUEST, FAIL, "refresh Token 이 만료되었습니다", null);
             }
         }
 
         res.put("Access Token", accessToken);
         res.put("Refresh Token", refreshToken);
 
-        return ResponseEntity.status(HttpStatus.OK).body(res);
+        return new ApiResponseDTO<>(OK, SUCCESS, "access token 갱신 완료", res);
     }
 }

--- a/vitalroutes/src/main/java/swyg/vitalroutes/security/domain/KakaoTokenResponse.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/security/domain/KakaoTokenResponse.java
@@ -1,0 +1,34 @@
+package swyg.vitalroutes.security.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoTokenResponse {
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("id_token")
+    private String idToken;
+
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("refresh_token_expires_in")
+    private Integer refreshTokenExpiresIn;
+
+    @JsonProperty("scope")
+    private String scope;   // 여러 개인 경우 공백으로 구분
+
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/security/domain/KakaoUserInfoResponse.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/security/domain/KakaoUserInfoResponse.java
@@ -1,0 +1,24 @@
+package swyg.vitalroutes.security.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoUserInfoResponse {
+    @JsonProperty("id")
+    private Long id;
+
+    @JsonProperty("properties")
+    private KakaoProperties properties;
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class KakaoProperties {
+        private String nickname;
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/security/domain/RefreshTokenDTO.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/security/domain/RefreshTokenDTO.java
@@ -1,7 +1,9 @@
 package swyg.vitalroutes.security.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+@Schema(description = "Body 에 담긴 Refresh Token 을 담는 DTO")
 @Data
 public class RefreshTokenDTO {
     private String refreshToken;

--- a/vitalroutes/src/main/java/swyg/vitalroutes/security/domain/RefreshTokenDTO.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/security/domain/RefreshTokenDTO.java
@@ -1,0 +1,8 @@
+package swyg.vitalroutes.security.domain;
+
+import lombok.Data;
+
+@Data
+public class RefreshTokenDTO {
+    private String refreshToken;
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/security/domain/SocialMemberDTO.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/security/domain/SocialMemberDTO.java
@@ -1,0 +1,32 @@
+package swyg.vitalroutes.security.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Schema(description = "최초 소셜 로그인 시 사용")
+@Data
+public class SocialMemberDTO {
+    
+    @NotBlank(message = "이름은 필수입력값 입니다")
+    private String name;
+
+    @NotBlank(message = "닉네임은 필수입력값 입니다")
+    @Size(min = 3, max = 16, message = "닉네임은 3자에서 16자까지 입력 가능합니다")
+    @Pattern(regexp = "[0-9|a-z|A-Z|ㄱ-ㅎ|ㅏ-ㅣ|가-힣|\\-|_|]*", message = "특수문자 없이 최소 3자에서 최대 16자까지 입력 가능합니다")
+    @Schema(description = "3자에서 16자 사이로 입력 가능")
+    private String nickname;
+
+    @NotBlank(message = "소셜 ID 전달되지 않음")
+    @Schema(description = "사용자가 보거나 수정하면 안됨")
+    private String socialId;
+
+    @NotBlank(message = "소셜 Type 전달되지 않음")
+    @Schema(description = "사용자가 보거나 수정하면 안됨")
+    private String socialType;
+
+    @Schema(description = "닉네임 중복 확인 후, 해당 필드를 true 로 보내주어야 함")
+    private Boolean isChecked = false;
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/security/filter/JwtVerifyFilter.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/security/filter/JwtVerifyFilter.java
@@ -12,6 +12,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.PatternMatchUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import swyg.vitalroutes.common.exception.JwtTokenException;
+import swyg.vitalroutes.common.response.ApiResponseDTO;
 import swyg.vitalroutes.security.utils.JwtConstants;
 import swyg.vitalroutes.security.utils.JwtTokenProvider;
 
@@ -55,10 +56,12 @@ public class JwtVerifyFilter extends OncePerRequestFilter {
         } catch (JwtTokenException exception) {
 
             response.setContentType("application/json; charset=UTF-8");
-            response.setStatus(exception.getStatusCode());
+            response.setStatus(exception.getStatus().value());
+
+            ApiResponseDTO<Object> apiResponse = new ApiResponseDTO<>(exception.getStatus(), exception.getType(), exception.getMessage(), null);
 
             ObjectMapper objectMapper = new ObjectMapper();
-            String json = objectMapper.writeValueAsString(Map.of("error", exception.getMessage()));
+            String json = objectMapper.writeValueAsString(apiResponse);
 
             PrintWriter printWriter = response.getWriter();
             printWriter.println(json);

--- a/vitalroutes/src/main/java/swyg/vitalroutes/security/filter/JwtVerifyFilter.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/security/filter/JwtVerifyFilter.java
@@ -26,7 +26,7 @@ public class JwtVerifyFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
 
     private static final String[] whitelist = {"/", "/member/duplicateCheck" ,"/member/signUp", "/member/login", "/token/refresh", "/post/**",
-            "/swagger-ui/**", "/v3/api-docs", "/v3/api-docs/**"};
+            "/swagger-ui/**", "/v3/api-docs", "/v3/api-docs/**", "/oauth2/**"};
 
     // 필터를 거치지 않을 URL 을 설정하고, true 를 return 하면 현재 필터를 건너뛰고 다음 필터로 이동
     @Override

--- a/vitalroutes/src/main/java/swyg/vitalroutes/security/handler/CommonLoginFailHandler.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/security/handler/CommonLoginFailHandler.java
@@ -4,8 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import swyg.vitalroutes.common.response.ApiResponseDTO;
+import swyg.vitalroutes.common.response.ResponseType;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -18,8 +21,10 @@ public class CommonLoginFailHandler implements AuthenticationFailureHandler {
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
         log.info("--------------------------- CommonLoginFailHandler ---------------------------");
 
+        ApiResponseDTO<Object> apiResponse = new ApiResponseDTO<>(HttpStatus.BAD_REQUEST, ResponseType.FAIL, "아이디 또는 비밀번호가 일치하지 않습니다", null);
+
         ObjectMapper objectMapper = new ObjectMapper();
-        String json = objectMapper.writeValueAsString(Map.of("error", "아이디 또는 비밀번호가 일치하지 않습니다."));
+        String json = objectMapper.writeValueAsString(apiResponse);
 
         response.setStatus(400);
         response.setContentType("application/json;charset=UTF-8");

--- a/vitalroutes/src/main/java/swyg/vitalroutes/security/handler/CommonLoginSuccessHandler.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/security/handler/CommonLoginSuccessHandler.java
@@ -6,8 +6,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import swyg.vitalroutes.common.response.ApiResponseDTO;
+import swyg.vitalroutes.common.response.ResponseType;
 import swyg.vitalroutes.member.domain.Member;
 import swyg.vitalroutes.security.domain.UserDetailsImpl;
 import swyg.vitalroutes.security.utils.JwtConstants;
@@ -34,8 +37,10 @@ public class CommonLoginSuccessHandler implements AuthenticationSuccessHandler {
         claims.put("accessToken", jwtTokenProvider.generateToken(claims, JwtConstants.ACCESS_EXP_TIME));
         claims.put("refreshToken", jwtTokenProvider.generateToken(claims, JwtConstants.REFRESH_EXP_TIME));
 
+        ApiResponseDTO<Map<String, Object>> apiResponse = new ApiResponseDTO<>(HttpStatus.OK, ResponseType.SUCCESS, "로그인 성공", claims);
+
         ObjectMapper objectMapper = new ObjectMapper();
-        String json = objectMapper.writeValueAsString(claims);
+        String json = objectMapper.writeValueAsString(apiResponse);
 
         response.setStatus(200);
         response.setContentType("application/json;charset=UTF-8");

--- a/vitalroutes/src/main/java/swyg/vitalroutes/security/service/KakaoLoginService.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/security/service/KakaoLoginService.java
@@ -1,0 +1,114 @@
+package swyg.vitalroutes.security.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+import swyg.vitalroutes.common.exception.KakaoLoginException;
+import swyg.vitalroutes.member.domain.Member;
+import swyg.vitalroutes.member.domain.SocialType;
+import swyg.vitalroutes.member.repository.MemberRepository;
+import swyg.vitalroutes.security.domain.KakaoTokenResponse;
+import swyg.vitalroutes.security.domain.KakaoUserInfoResponse;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoLoginService {
+
+    @Value("${kakao.login.client-id}")
+    private String restAPiKey;
+
+    @Value("${kakao.login.redirect-uri}")
+    private String redirectURI;
+
+    private final MemberRepository memberRepository;
+
+    public Optional<Member> findMember(String socialId, SocialType socialType) {
+        return memberRepository.findBySocialIdAndSocialType(socialId, socialType);
+    }
+
+    public String[] kakaoLogin(String code) {
+        String accessToken = getAccessToken(code);
+        return getUserInfo(accessToken);
+    }
+
+    public String getAccessToken(String code) {
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        // Header
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // Body
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<String, String>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", restAPiKey);
+        body.add("redirect_uri", redirectURI);
+        body.add("code", code);
+
+        // Header 와 Body 를 가진 Request 생성
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+        String accessTokenUri = "https://kauth.kakao.com/oauth/token";
+        UriComponents uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(accessTokenUri).build();
+
+        // HTTP POST 요청
+        ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(uriComponentsBuilder.toUri(), HttpMethod.POST, request, KakaoTokenResponse.class);
+
+        if (response.getStatusCode().value() != 200) {
+            throw new KakaoLoginException(response.getStatusCode().value(), "Access Token 을 받는 중 문제가 발생하였습니다");
+        }
+        
+        KakaoTokenResponse responseBody = response.getBody();
+        String accessToken = responseBody.getAccessToken();
+        return accessToken;
+    }
+
+    public String[] getUserInfo(String accessToken) {
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        // Header
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        HttpEntity<String> request = new HttpEntity<>(headers);
+
+        String userInfoUri = "https://kapi.kakao.com/v2/user/me";
+        UriComponents uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(userInfoUri).build();
+
+        ResponseEntity<KakaoUserInfoResponse> response = restTemplate.exchange(uriComponentsBuilder.toUri(), HttpMethod.GET, request, KakaoUserInfoResponse.class);
+
+        if (response.getStatusCode().value() != 200) {
+            throw new KakaoLoginException(response.getStatusCode().value(), "사용자 정보를 받는 중 문제가 발생하였습니다");
+        }
+
+        KakaoUserInfoResponse responseBody = response.getBody();
+        String socialId = String.valueOf(responseBody.getId());
+        String nickname = responseBody.getProperties().getNickname();
+
+        log.info("socialId = {}", socialId);
+        log.info("nickname = {}", nickname);
+        return new String[]{socialId, nickname};
+    }
+
+
+
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/security/service/KakaoLoginService.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/security/service/KakaoLoginService.java
@@ -3,10 +3,7 @@ package swyg.vitalroutes.security.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -14,6 +11,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 import swyg.vitalroutes.common.exception.KakaoLoginException;
+import swyg.vitalroutes.common.response.ResponseType;
 import swyg.vitalroutes.member.domain.Member;
 import swyg.vitalroutes.member.domain.SocialType;
 import swyg.vitalroutes.member.repository.MemberRepository;
@@ -72,7 +70,7 @@ public class KakaoLoginService {
         ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(uriComponentsBuilder.toUri(), HttpMethod.POST, request, KakaoTokenResponse.class);
 
         if (response.getStatusCode().value() != 200) {
-            throw new KakaoLoginException(response.getStatusCode().value(), "Access Token 을 받는 중 문제가 발생하였습니다");
+            throw new KakaoLoginException(HttpStatus.INTERNAL_SERVER_ERROR, ResponseType.ERROR, "Access Token 을 받는 중 문제가 발생하였습니다");
         }
         
         KakaoTokenResponse responseBody = response.getBody();
@@ -97,7 +95,7 @@ public class KakaoLoginService {
         ResponseEntity<KakaoUserInfoResponse> response = restTemplate.exchange(uriComponentsBuilder.toUri(), HttpMethod.GET, request, KakaoUserInfoResponse.class);
 
         if (response.getStatusCode().value() != 200) {
-            throw new KakaoLoginException(response.getStatusCode().value(), "사용자 정보를 받는 중 문제가 발생하였습니다");
+            throw new KakaoLoginException(HttpStatus.INTERNAL_SERVER_ERROR, ResponseType.ERROR, "사용자 정보를 받는 중 문제가 발생하였습니다");
         }
 
         KakaoUserInfoResponse responseBody = response.getBody();

--- a/vitalroutes/src/main/java/swyg/vitalroutes/security/utils/JwtTokenProvider.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/security/utils/JwtTokenProvider.java
@@ -1,13 +1,11 @@
 package swyg.vitalroutes.security.utils;
 
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.stereotype.Component;
 import swyg.vitalroutes.common.exception.JwtTokenException;
 import swyg.vitalroutes.member.domain.Member;
 import swyg.vitalroutes.security.domain.UserDetailsImpl;
@@ -18,6 +16,9 @@ import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Map;
 
+import static org.springframework.http.HttpStatus.*;
+import static swyg.vitalroutes.common.response.ResponseType.*;
+
 public class JwtTokenProvider {
 
     @Value("${jwt.secretKey}")
@@ -26,9 +27,9 @@ public class JwtTokenProvider {
     // Bearer XXX 형태로 토큰이 전달되는지 체크
     public void checkAuthorizationHeader(String header) {
         if(header == null) {
-            throw new JwtTokenException(400, "토큰이 전달되지 않았습니다");
+            throw new JwtTokenException(BAD_REQUEST, FAIL, "토큰이 전달되지 않았습니다");
         } else if (!header.startsWith(JwtConstants.JWT_TYPE)) {
-            throw new JwtTokenException(400, "올바르지 않은 토큰 형식입니다");
+            throw new JwtTokenException(BAD_REQUEST, FAIL, "올바르지 않은 토큰 형식입니다");
         }
     }
 
@@ -85,9 +86,9 @@ public class JwtTokenProvider {
                     .parseClaimsJws(token) // 파싱 및 검증, 실패 시 에러
                     .getBody();
         } catch(ExpiredJwtException expiredJwtException){
-            throw new JwtTokenException(401, "토큰이 만료되었습니다");
+            throw new JwtTokenException(UNAUTHORIZED, FAIL, "토큰이 만료되었습니다");
         } catch(Exception e){
-            throw new JwtTokenException(400, "토큰이 올바르지 않습니다");
+            throw new JwtTokenException(BAD_REQUEST, FAIL, "올바르지 않은 토큰 형식입니다");
         }
         return claim;
     }
@@ -100,7 +101,7 @@ public class JwtTokenProvider {
         try {
             validateToken(token);
         } catch (JwtTokenException exception) {
-            return (exception.getStatusCode() == 401);
+            return (exception.getStatus() == UNAUTHORIZED);
         }
         return false;
     }

--- a/vitalroutes/src/main/resources/application.yml
+++ b/vitalroutes/src/main/resources/application.yml
@@ -38,3 +38,7 @@ cloud:
 jwt:
   secretKey: ENC(m3IxdMw3rZhPueIyGSClgkAQOviME+/yA6S+AETPaarWVD2ovNemTeLn1KfHGDSH9eEcX7BlprKJa4ew4W3gT+ixH9R6JPqOVc2WUVOYOOSNGP4I6ANgEA==)
 
+kakao:
+  login:
+    client-id: ENC(DINFbAY/RI0maEuCPDXuQcCQNp4+CxtI7O+wFoDI1ohNpHMAWvKNo71lDMLPaAy3)
+    redirect-uri: ENC(io/BNG3FIRVo5Elr8qJvP26KazkACWMxO9keK11My/JZZ1jUrvAcvHwAIhuV1j+J)


### PR DESCRIPTION
### 카카오 소셜 로그인
- 로그인 페이지 리다이렉트 API
- 인가코드 및 사용자 정보 받는 API
- 로그인 성공 시 SUCCESS type 과 함께 로그인 정보, token 반환
- 최초 로그인 시, ONGOING type 과 함께 회원 생성 DTO 반환
- 닉네임을 입력받지 않으면 회원이 저장되지 않는다

### API 정리
-  Swagger 를 이용해 현재까지 구현된 API 및 Schema 정리 완료

### API 응답 스펙
```
{
    "status": "",
    "type": "",
    "message": "",
    "data": ""
}
```
- **status** : HttpStatus 존재, 숫자로 표현되는 상태는 아님, Swagger 에서 `ApiResponseDTO `보면 모든 상태 확인 가능
- **type** : 임의로 생성( 소셜 로그인 후에 최초 로그인과 구분하기 위해 ), 마찬가지로 swagger 에서 모든 value 확인 가능
- **message** : 성공과 실패 모두 여기에 메세지가 담겨서 반환됨
- **data** : 반환되는 데이터는 모두 여기에 담겨서 반환, 데이터를 전달할 필요가 없는 경우 null

resolves #14 