### PR TITLE
회원정보수정

### DIFF
--- a/vitalroutes/build.gradle
+++ b/vitalroutes/build.gradle
@@ -36,6 +36,8 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'	// Swagger SpringDoc
 
 	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.3'	// yml 암호화 jasypt 라이브러리
+
+	implementation 'org.springframework.boot:spring-boot-starter-mail'	// 이메일 라이브러리
 	
 
 	// JJWT

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/controller/ApiExceptionController.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/controller/ApiExceptionController.java
@@ -1,15 +1,13 @@
 package swyg.vitalroutes.common.controller;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import swyg.vitalroutes.common.exception.JwtTokenException;
 import swyg.vitalroutes.common.exception.KakaoLoginException;
+import swyg.vitalroutes.common.exception.MemberModifyException;
 import swyg.vitalroutes.common.exception.MemberSignUpException;
 import swyg.vitalroutes.common.response.ApiResponseDTO;
 
-import java.util.Map;
 
 @RestControllerAdvice
 public class ApiExceptionController {
@@ -25,6 +23,11 @@ public class ApiExceptionController {
 
     @ExceptionHandler(KakaoLoginException.class)
     public ApiResponseDTO<?> kakaoLoginEx(KakaoLoginException exception) {
+        return new ApiResponseDTO<>(exception.getStatus(), exception.getType(), exception.getMessage(), null);
+    }
+
+    @ExceptionHandler(MemberModifyException.class)
+    public ApiResponseDTO<?> memberModifyEx(MemberModifyException exception) {
         return new ApiResponseDTO<>(exception.getStatus(), exception.getType(), exception.getMessage(), null);
     }
 }

--- a/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/MemberModifyException.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/common/exception/MemberModifyException.java
@@ -1,0 +1,17 @@
+package swyg.vitalroutes.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import swyg.vitalroutes.common.response.ResponseType;
+
+@Getter
+public class MemberModifyException extends RuntimeException {
+    public HttpStatus status;
+    public ResponseType type;
+
+    public MemberModifyException(HttpStatus status, ResponseType type, String message) {
+        super(message);
+        this.status = status;
+        this.type = type;
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/controller/MemberController.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/controller/MemberController.java
@@ -1,6 +1,8 @@
 package swyg.vitalroutes.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -11,6 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.core.parameters.P;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
@@ -140,7 +143,18 @@ public class MemberController {
         return new ApiResponseDTO<>(CREATED, SUCCESS, "회원가입이 완료되었습니다", null);
     }
 
-
+    @Operation(description = "회원의 프로필 정보를 가져오는 API", summary = "회원 정보 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "OK SUCCESS",
+                    description = "회원정보 정상 조회, API 응답 스펙의 data 에 해당 정보가 들어있음",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberModifyDTO.class))),
+            @ApiResponse(responseCode = "NOT_FOUND FAIL",
+                    description = "존재하는 회원이 아님",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponseDTO.class)))
+    })
+    @Parameters(value = {
+            @Parameter(name = "memberId", required = true, description = "로그인 후에 토큰과 함께 전달 받은 회원번호")
+    })
     @GetMapping("/member/profile/{memberId}")
     public ApiResponseDTO<?> viewMemberInfo(@PathVariable Long memberId) {
         Optional<Member> optionalMember = memberService.getMemberInfo(memberId);
@@ -151,6 +165,18 @@ public class MemberController {
     }
 
 
+    @Operation(description = "회원 정보를 수정하는 API, 수정하는 정보만 전달, 수정되지 않은 데이터는 null", summary = "회원 수정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "OK SUCCESS",
+                    description = "회원정보 수정 완료, data 에 memberId, name, profile, email, access token, refresh token 이 존재",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponseDTO.class))),
+            @ApiResponse(responseCode = "NOT_FOUND FAIL",
+                    description = "존재하는 회원이 아님",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponseDTO.class))),
+            @ApiResponse(responseCode = "CONFLICT FAIL",
+                    description = "DB 에 닉네임이나 이메일이 존재",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponseDTO.class)))
+    })
     @PatchMapping("/member/profile/{memberId}")
     public ApiResponseDTO<?> modifyMemberInfo(@PathVariable Long memberId, @RequestBody MemberModifyDTO memberDto) {
         log.info("memberDto = {}", memberDto);
@@ -172,9 +198,23 @@ public class MemberController {
         return new ApiResponseDTO<>(OK, SUCCESS, "회원정보 수정이 완료되었습니다", claims);
     }
 
+
+    @Operation(description = "회원탈퇴 API", summary = "회원 탈퇴")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "OK SUCCESS",
+                    description = "회원탈퇴 완료",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponseDTO.class))),
+            @ApiResponse(responseCode = "NOT_FOUND FAIL",
+                    description = "존재하는 회원이 아님",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponseDTO.class)))
+    })
     @DeleteMapping("/member/profile/{memberId}")
     public ApiResponseDTO<?> deleteMember(@PathVariable Long memberId) {
-        memberService.deleteMember(memberId);
+        try {
+            memberService.deleteMember(memberId);
+        } catch (NoSuchElementException exception) {
+            return new ApiResponseDTO<>(NOT_FOUND, FAIL, "존재하지 않는 회원입니다", null);
+        }
         return new ApiResponseDTO<>(OK, SUCCESS, "회원탈퇴가 완료되었습니다", null);
     }
 
@@ -183,6 +223,15 @@ public class MemberController {
      * 1. S3 에 이미지를 업로드 하는 API 를 호출한다 -> formData
      * 2. 프로필 이미지를 수정하는 API 를 호출한다 -> formData
      */
+    @Operation(description = "프로필 이미지를 S3 에 업로드하는 API, form-data 형식으로 profileImage 에 전달 필요", summary = "프로필 이미지 업로드")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "OK SUCCESS",
+                    description = "이미지 업로드 완료, data 에 imageURL 이라는 키값으로 업로드된 URL 을 반환",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponseDTO.class))),
+            @ApiResponse(responseCode = "INTERNAL_SERVER_ERROR",
+                    description = "이미지 업로드 중 에러 발생",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponseDTO.class)))
+    })
     @PostMapping("/member/profile/image")
     public ApiResponseDTO<?> uploadProfileImage(MemberProfileImageDTO imageDTO) {
         log.info("imageDTO = {}", imageDTO);
@@ -197,6 +246,15 @@ public class MemberController {
         return new ApiResponseDTO<>(OK, SUCCESS, "프로필 이미지 업로드가 완료되었습니다", Map.of("imageURL", imageURL));
     }
 
+    @Operation(description = "프로필 이미지를 변경하는 API, form-data 형식으로 profileImageURL 전달 필요", summary = "프로필 이미지 변경")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "OK SUCCESS",
+                    description = "프로필 이미지 수정 완료",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponseDTO.class))),
+            @ApiResponse(responseCode = "BAD_REQUEST FAIL",
+                    description = "프로필 이미지 URL 전달되지 않음",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponseDTO.class)))
+    })
     @PatchMapping("/member/profile/image/{memberId}")
     public ApiResponseDTO<?> modifyProfileImage(@PathVariable Long memberId, MemberProfileImageDTO imageDTO) {
         log.info("imageDTO = {}", imageDTO);
@@ -215,6 +273,18 @@ public class MemberController {
      * 2. email 이 유효하면 해당 주소로 재설정 이메일을 보낸다. 이때 URI 뒤쪽에 식별자 비슷하게 붙는게 하나 있음
      * 3. 재설정 이메일에 접속한 후에 새로운 비밀번호를 입력해서 전달한다. API 요청 시 뒤에 붙은 식별자도 함께 전달해주어야함
      */
+    @Operation(description = "비밀번호 재설정 링크롤 보내는 API", summary = "비밀번호 재설정 이메일 전송")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "OK SUCCESS",
+                    description = "비밀번호 재설정 링크가 전송 완료",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponseDTO.class))),
+            @ApiResponse(responseCode = "NOT_FOUND FAIL",
+                    description = "존재하지 않는 이메일",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponseDTO.class))),
+            @ApiResponse(responseCode = "INTERNAL_SERVER_ERROR",
+                    description = "이메일 발송 실패",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponseDTO.class)))
+    })
     @PostMapping("/member/password")
     public ApiResponseDTO<?> sendPasswordEmail(@RequestBody MemberEmailDTO emailDTO) {
         String email = emailDTO.getEmail();
@@ -245,6 +315,18 @@ public class MemberController {
         return new ApiResponseDTO<>(OK, SUCCESS, "비밀번호 재설정 링크가 전송되었습니다", null);
     }
 
+    @Operation(description = "비밀번호 재설정 API", summary = "비밀번호 재설정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "OK SUCCESS",
+                    description = "비밀번호 변경 완료",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponseDTO.class))),
+            @ApiResponse(responseCode = "NOT_FOUND FAIL",
+                    description = "비밀번호 재설정 링크의 유효시간이 지남( 5분 )",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponseDTO.class)))
+    })
+    @Parameters(value = {
+            @Parameter(name = "token", required = true, description = "비밀번호 재설정 링크는 /member/password/xxxx 형태인데 뒤에 붙은 xxx 전달 필요")
+    })
     @PatchMapping("/member/password/{token}")
     public ApiResponseDTO<?> modifyPassword(@PathVariable String token, @RequestBody MemberPasswordDTO passwordDTO) {
         log.info("token = {}", token);

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/Member.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/Member.java
@@ -1,16 +1,14 @@
 package swyg.vitalroutes.member.domain;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberEmailDTO.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberEmailDTO.java
@@ -1,0 +1,8 @@
+package swyg.vitalroutes.member.domain;
+
+import lombok.Data;
+
+@Data
+public class MemberEmailDTO {
+    String email;
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberModifyDTO.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberModifyDTO.java
@@ -1,7 +1,9 @@
 package swyg.vitalroutes.member.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+@Schema(description = "회원 정보 수정 시 사용, 수정하는 정보만 담아서 전달해야함")
 @Data
 public class MemberModifyDTO {
     private Long memberId;
@@ -10,7 +12,9 @@ public class MemberModifyDTO {
     private String nickname;
     private String email;
 
+    @Schema(description = "이전 비밀번호, 비밀번호 변경 시, 신규 비밀번호와 함께 보내주어야함")
     private String prePassword;
+    @Schema(description = "신규 비밀번호, 규칙 준수 여부 판단 로직도 작성되어 있음")
     private String newPassword;
 
     public static MemberModifyDTO entityToDto(Member member) {

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberModifyDTO.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberModifyDTO.java
@@ -1,0 +1,25 @@
+package swyg.vitalroutes.member.domain;
+
+import lombok.Data;
+
+@Data
+public class MemberModifyDTO {
+    private Long memberId;
+    private String profile;
+    private String name;
+    private String nickname;
+    private String email;
+
+    private String prePassword;
+    private String newPassword;
+
+    public static MemberModifyDTO entityToDto(Member member) {
+        MemberModifyDTO dto = new MemberModifyDTO();
+        dto.setMemberId(member.getMemberId());
+        dto.setProfile(member.getProfile());
+        dto.setName(member.getName());
+        dto.setNickname(member.getNickname());
+        dto.setEmail(member.getEmail());
+        return dto;
+    }
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberPasswordDTO.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberPasswordDTO.java
@@ -1,0 +1,8 @@
+package swyg.vitalroutes.member.domain;
+
+import lombok.Data;
+
+@Data
+public class MemberPasswordDTO {
+    private String password;
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberPasswordDTO.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberPasswordDTO.java
@@ -1,7 +1,9 @@
 package swyg.vitalroutes.member.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+@Schema(description = "이메일로 비밀번호 재설정 링크를 받았을 때 비밀번호 변경을 위해 사용")
 @Data
 public class MemberPasswordDTO {
     private String password;

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberProfileImageDTO.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberProfileImageDTO.java
@@ -1,10 +1,15 @@
 package swyg.vitalroutes.member.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.springframework.web.multipart.MultipartFile;
 
+@Schema(description = "프로필 이미지를 수정할 때 사용, form-data 형식으로 전송 필요")
 @Data
 public class MemberProfileImageDTO {
+    @Schema(description = "S3에 프로필 이미지를 업로드할 때 사용하는 필드")
     private MultipartFile profileImage;
+
+    @Schema(description = "업로드 이후 전달 받은 URL 로 프로필 이미지를 변경할 때 URL 을 담는 필드")
     private String profileImageURL;
 }

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberProfileImageDTO.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/domain/MemberProfileImageDTO.java
@@ -1,0 +1,10 @@
+package swyg.vitalroutes.member.domain;
+
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+public class MemberProfileImageDTO {
+    private MultipartFile profileImage;
+    private String profileImageURL;
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/service/MailService.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/service/MailService.java
@@ -1,0 +1,35 @@
+package swyg.vitalroutes.member.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender mailSender;
+    private final SpringTemplateEngine templateEngine;
+
+    public void sendEmail(String name, String email, String url) throws MessagingException {
+        MimeMessage message = mailSender.createMimeMessage();
+        message.addRecipients(MimeMessage.RecipientType.TO, email);
+        message.setSubject("VitalRoutes 비밀번호 재설정 링크입니다");
+        message.setText(setContent(name, url), "utf-8", "html");
+        mailSender.send(message);
+    }
+
+    public String setContent(String name, String url) {
+        Context context = new Context();
+        context.setVariable("name", name);
+        context.setVariable("url", url);
+        return templateEngine.process("mailTemplate", context);
+    }
+
+}

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/service/MemberService.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/service/MemberService.java
@@ -14,6 +14,7 @@ import swyg.vitalroutes.member.domain.SocialType;
 import swyg.vitalroutes.member.repository.MemberRepository;
 import swyg.vitalroutes.security.domain.SocialMemberDTO;
 
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import static org.springframework.http.HttpStatus.*;
@@ -60,6 +61,10 @@ public class MemberService {
     }
 
     public void deleteMember(Long memberId) {
+        Optional<Member> optionalMember = memberRepository.findById(memberId);
+        if (optionalMember.isEmpty()) {
+            throw new NoSuchElementException();
+        }
         memberRepository.deleteById(memberId);
     }
 

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/service/MemberService.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/service/MemberService.java
@@ -128,4 +128,27 @@ public class MemberService {
         return member;
     }
 
+    public Optional<Member> findMemberByEmail(String email) {
+        return memberRepository.findByEmail(email);
+    }
+
+
+    public void modifyPassword(Long memberId, String password) {
+        // 사용자 존재하는지 다시 확인
+        Optional<Member> optionalMember = memberRepository.findById(memberId);
+        if (optionalMember.isEmpty()) {
+            throw new MemberModifyException(BAD_REQUEST, FAIL, "사용자가 존재하지 않습니다");
+        }
+
+        // 비밀번호 규칙을 준수하는지 확인
+        String regex = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,20}$";
+        boolean matches = password.matches(regex);
+        if (!matches) {
+            throw new MemberModifyException(BAD_REQUEST, FAIL, "비밀번호는 대문자, 소문자, 숫자를 포함한 최소 8자 이상, 20자 이하여야 합니다");
+        }
+
+        Member member = optionalMember.get();
+        member.setPassword(passwordEncoder.encode(password));
+    }
+
 }

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/service/MemberService.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/service/MemberService.java
@@ -1,10 +1,14 @@
 package swyg.vitalroutes.member.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import swyg.vitalroutes.common.exception.MemberModifyException;
 import swyg.vitalroutes.member.domain.Member;
+import swyg.vitalroutes.member.domain.MemberModifyDTO;
 import swyg.vitalroutes.member.domain.MemberSaveDTO;
 import swyg.vitalroutes.member.domain.SocialType;
 import swyg.vitalroutes.member.repository.MemberRepository;
@@ -12,6 +16,10 @@ import swyg.vitalroutes.security.domain.SocialMemberDTO;
 
 import java.util.Optional;
 
+import static org.springframework.http.HttpStatus.*;
+import static swyg.vitalroutes.common.response.ResponseType.*;
+
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -44,6 +52,69 @@ public class MemberService {
                 .socialType(SocialType.valueOf(memberDTO.getSocialType()))
                 .build();
         return memberRepository.save(member);
+    }
+
+
+    public Optional<Member> getMemberInfo(Long memberId) {
+        return memberRepository.findById(memberId);
+    }
+
+    public void deleteMember(Long memberId) {
+        memberRepository.deleteById(memberId);
+    }
+
+
+    public Member modifyMemberInfo(Long memberId, MemberModifyDTO memberModifyDTO) {
+        Member member = memberRepository.findById(memberId).get();  // controller 에서 예외처리
+
+        boolean socialFlag = false;
+        if (member.getSocialId() != null) {
+            socialFlag = true;
+        }
+
+        /**
+         * 1. 변경할 데이터만 전달 받는다
+         * 2. 닉네임이 전달되면 DB 중복 확인이 필요
+         * 3. 이메일 변경된 경우 -> 소셜 회원이라면 ok, 일반 회원이라면 이메일은 삭제 불가
+         * 4. 이전 비밀번호는 일치하는지 확인, 새 비밀번호는 규칙에 맞는지 확인
+         */
+
+        if (memberModifyDTO.getName() != null) {
+            // 일반 JPA 와 동일하게 엔티티 변경하면 하면 커밋 시점에 자동으로 update
+            member.setName(memberModifyDTO.getName());
+        }
+
+        if (memberModifyDTO.getNickname() != null) {
+            // 닉네임 중복 확인을 하지 않았더라도 DB 에 저장될 때 유니크 제약조건에 의해 예외 발생 -> Controller 에서 처리
+            member.setNickname(memberModifyDTO.getNickname());
+        }
+
+        if (memberModifyDTO.getEmail() != null) {
+            // 이메일이 비어있는데 일반 회원인 경우
+            if (!StringUtils.hasText(memberModifyDTO.getEmail()) && !socialFlag) {
+                throw new MemberModifyException(BAD_REQUEST, FAIL, "일반회원은 이메일을 비워둘 수 없습니다");
+            }
+            member.setEmail(memberModifyDTO.getEmail());
+        }
+
+        if (memberModifyDTO.getNewPassword() != null && memberModifyDTO.getPrePassword() == null) {
+            throw new MemberModifyException(BAD_REQUEST, FAIL, "비밀번호 변경 시에는 이전 비밀번호와 새 비밀번호를 입력해주세요");
+        } else if (memberModifyDTO.getNewPassword() != null && memberModifyDTO.getPrePassword() != null) {
+            // 1. 이전 비밀번호 일치여부 확인
+            boolean matchePre = passwordEncoder.matches(memberModifyDTO.getPrePassword(), member.getPassword());
+            if (!matchePre) { // 일치하지 않는 경우
+                throw new MemberModifyException(BAD_REQUEST, FAIL, "이전 비밀번호가 일치하지 않습니다");
+            }
+            // 2. 새로운 비밀번호 규칙 준수 확인
+            String regex = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,20}$";
+            boolean matchNew = memberModifyDTO.getNewPassword().matches(regex);
+            if (!matchNew) {
+                throw new MemberModifyException(BAD_REQUEST, FAIL, "비밀번호는 대문자, 소문자, 숫자를 포함한 최소 8자 이상, 20자 이하여야 합니다");
+            }
+            member.setPassword(passwordEncoder.encode(memberModifyDTO.getNewPassword()));
+        }
+
+        return member;
     }
 
 }

--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/service/MemberService.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/service/MemberService.java
@@ -117,4 +117,15 @@ public class MemberService {
         return member;
     }
 
+
+    public Member modifyProfileImage(Long memberId, String imageURL) {
+        Optional<Member> optionalMember = memberRepository.findById(memberId);
+        if (optionalMember.isEmpty()) {
+            throw new MemberModifyException(BAD_REQUEST, FAIL, "사용자가 존재하지 않습니다");
+        }
+        Member member = optionalMember.get();
+        member.setProfile(imageURL);
+        return member;
+    }
+
 }

--- a/vitalroutes/src/main/java/swyg/vitalroutes/s3/S3UploadService.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/s3/S3UploadService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -23,7 +24,11 @@ public class S3UploadService {
     private String bucket;
 
     public String saveFile(MultipartFile multipartFile) throws IOException {
-        String originalFilename = multipartFile.getOriginalFilename();
+        StringBuffer sb = new StringBuffer();
+        sb.append(UUID.randomUUID());
+        sb.append("-");
+        sb.append(multipartFile.getOriginalFilename());
+        String originalFilename = sb.toString();
 
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(multipartFile.getSize());

--- a/vitalroutes/src/main/java/swyg/vitalroutes/security/filter/JwtVerifyFilter.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/security/filter/JwtVerifyFilter.java
@@ -27,7 +27,7 @@ public class JwtVerifyFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
 
     private static final String[] whitelist = {"/", "/member/duplicateCheck" ,"/member/signUp", "/member/login", "/token/refresh", "/post/**",
-            "/swagger-ui/**", "/v3/api-docs", "/v3/api-docs/**", "/oauth2/**"};
+            "/swagger-ui/**", "/v3/api-docs", "/v3/api-docs/**", "/oauth2/**", "/member/password", "/member/password/**"};
 
     // 필터를 거치지 않을 URL 을 설정하고, true 를 return 하면 현재 필터를 건너뛰고 다음 필터로 이동
     @Override

--- a/vitalroutes/src/main/resources/application.yml
+++ b/vitalroutes/src/main/resources/application.yml
@@ -7,10 +7,25 @@ spring:
   thymeleaf:
     cache: false
 
+  # Image File Size
   servlet:
     multipart:
       max-file-size: 10MB
       max-request-size: 50MB
+
+  # Mail Service
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    properties:
+      mail:
+        debug: true
+        smtp.auth: true
+        smtp.timeout: 50000
+        smtp.starttls.enable: true
+    username: ENC(p5fGOcTWBiKYx1fGmNxj7eN/yiZcao+F3XO9NoEpjFAqrMvMU5QSlw==)
+    password: ENC(L1bCrwxo+b8i+mI7hAi5lhaVQD8rQNzrQjfx/ne53rg=)
+
 
   # spring data jpa ??
   jpa:

--- a/vitalroutes/src/main/resources/application.yml
+++ b/vitalroutes/src/main/resources/application.yml
@@ -7,6 +7,11 @@ spring:
   thymeleaf:
     cache: false
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 50MB
+
   # spring data jpa ??
   jpa:
       #database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
@@ -25,8 +30,8 @@ cloud:
     s3:
       bucket: vital-routes-bucket
     credentials:
-      access-key: ENC(2UXJ1AxBkq3TG2fwyJCs1vLw+/WrHm8AajRtFc2rwlA=)
-      secret-key: ENC(oaAgrjsbeLI9IIbNywgyUKqhytarQldrn6NcS+W/c2xQpVfydNgE+cCoKMxAquR4TRQQ0SPHHd8=)
+      access-key: ENC(u4ltBd8SKMXsj4wlWB4rk4+DyL4Y2MGUYHy/+IxpCY8=)
+      secret-key: ENC(Ym0xw87fc9L+nLjp88P/6gfcDILZYjbcU2R2fcNkZ2ieSEbXKfTEt5Y3jL9d5Tq5rOorHnk7A3A=)
       instanceProfile: true
     region:
       static: ap-northeast-2

--- a/vitalroutes/src/main/resources/templates/mailTemplate.html
+++ b/vitalroutes/src/main/resources/templates/mailTemplate.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<div>
+    <img src="https://vital-routes-bucket.s3.ap-northeast-2.amazonaws.com/524e308b-04ca-4a6e-a0c5-1b4df43e8f18-logo.PNG" width="400">
+</div>
+<div>
+    <h3 th:text="${name}">Hi, </h3>
+    <p style="color: gray">비밀번호 재설정 지침은 다음과 같습니다</p>
+</div>
+<hr>
+<div>
+    <div>
+        VitalRoutes 비밀번호 재설정 요청이 접수되었습니다. 이 요청을 하지 않으셨다면 이 이메일은 무시하시면 됩니다.
+        이 요청을 했다면 비밀번호를 재설정하세요
+    </div>
+    <br/>
+    <div>
+        <a th:href="${url}">암호를 재설정</a>
+    </div>
+    <br/>
+    <div>
+        고마워요,
+    </div>
+    <div>
+        팀 vitalRoutes
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
### 기능
- 이름, 닉네임, 이메일, 비밀번호 수정
- 프로필 이미지 업로드
- 비밀번호 재설정 링크 이메일 전송
- 회원 탈퇴

### 프로필 이미지 업로드 프로세스
1. S3 에 파일을 업로드하는 메서드를 호출해서 URL 을 반환받는다
2. URL 을 전송하여 DB에 있는 프로필 이미지 정보를 수정한다

### 비밀번호 변경 프로세스
1. 회원가입 시 사용한 이메일을 전달하면 `/member/password/xxxxx` 형태로 재설정 링크가 전달된다
2. 비밀번호를 재설정할 때 뒤에 있는 xxxx 까지 포함하여 호출한다

resolves #16 