### PR TITLE
feat: 챌린지 및 프론트 연결

### DIFF
--- a/vitalroutes/src/main/java/swyg/vitalroutes/member/controller/MemberController.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/member/controller/MemberController.java
@@ -294,7 +294,7 @@ public class MemberController {
             String token = jwtTokenProvider.generateToken(memberInfo, 5);  // 재설정 링크는 5분 동안 유효
 
             StringBuffer sb = new StringBuffer();
-            sb.append("http://localhost:8080/member/password/");    // 프론트 배포 후에 변경 필요
+            sb.append("https://vital-routes.vercel.app/member/password/");
             sb.append(token);
             String url = sb.toString();
 

--- a/vitalroutes/src/main/java/swyg/vitalroutes/participation/service/ParticipationService.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/participation/service/ParticipationService.java
@@ -19,11 +19,12 @@ import swyg.vitalroutes.participation.domain.Participation;
 import swyg.vitalroutes.participation.dto.*;
 import swyg.vitalroutes.participation.repository.ParticipationRepository;
 import swyg.vitalroutes.post.entity.BoardEntity;
+import swyg.vitalroutes.post.entity.BoardPathImageEntity;
+import swyg.vitalroutes.post.repository.BoardPathImageRepository;
 import swyg.vitalroutes.post.repository.BoardRepository;
 import swyg.vitalroutes.s3.S3UploadService;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 import static org.springframework.http.HttpStatus.*;
 import static swyg.vitalroutes.common.response.ResponseType.*;
@@ -73,30 +74,48 @@ public class ParticipationService {
 
 
     public void saveParticipation(Long memberId, ParticipationSaveDTO saveDTO) {
-        List<ParticipationImage> participationImages = new ArrayList<>();
-        List<MultipartFile> files = saveDTO.getFiles();
-        int seq = 0;
-
-        /**
-         * 아래 반복문 안에서 Board 의 Location 과 비교 필요
-         */
-        
-        for (MultipartFile file : files) {
-            String fileName = "file image url";
-            // String fileName = s3UploadService.saveFile(file);
-            double[] locationInfo = FileUtils.getLocationInfo(file);
-            participationImages.add(ParticipationImage.createParticipationImage(++seq, fileName));
-        }
-
         // 거치지 않아도 되지만 DB 에서 조회하는 걸로 남김
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ParticipationException(NOT_FOUND, FAIL, "사용자가 존재하지 않습니다"));
         BoardEntity board = boardRepository.findById(saveDTO.getBoardId())
                 .orElseThrow(() -> new ParticipationException(NOT_FOUND, FAIL, "게시글이 존재하지 않습니다"));
 
+        List<BoardPathImageEntity> boardPathImageEntityList = board.getBoardFileEntity().getBoardPathImageEntityList();
+        // 도착지를 먼저 저장하시니...내가 정렬을 해야지...;;
+        boardPathImageEntityList.sort(Comparator.comparing(BoardPathImageEntity::getLocationOnRoute));
+        log.info("boardPathImageEntityList size = {}", boardPathImageEntityList.size());
+        for (BoardPathImageEntity boardPathImageEntity : boardPathImageEntityList) {
+            System.out.println("boardPathImageEntity.getLocationOnRoute() = " + boardPathImageEntity.getLocationOnRoute());
+        }
+        
+        List<MultipartFile> files = saveDTO.getFiles(); // 전달 받은 이미지 파일
 
+        if (boardPathImageEntityList.size() != files.size()) {
+            throw new ParticipationException(BAD_REQUEST, FAIL, "게시글과 동일한 개수의 이미지를 업로드해주세요");
+        }
+
+        List<ParticipationImage> participationImages = new ArrayList<>();
+        int seq = 0;
+        
+        
+        for (MultipartFile file : files) {
+            String fileName = "file image url";
+            // String fileName = s3UploadService.saveFile(file);
+            double[] locationInfo = FileUtils.getLocationInfo(file);
+
+            // 거리 비교
+            double latitude = boardPathImageEntityList.get(seq).getLatitude();
+            double longitude = boardPathImageEntityList.get(seq).getLongitude();
+            double distance = FileUtils.calDistance(locationInfo[0], locationInfo[1], latitude, longitude);
+            log.info(seq + "번째 지점 distance = {}", distance);
+            if (distance > 5) {
+                throw new ParticipationException(BAD_REQUEST, FAIL, (seq + 1) + "번째 지점의 거리가 멀리 떨어져있습니다. 챌린지 지점과의 거리는 5m 이하여야 합니다. 현재거리 = " + (int) distance + "m");
+            }
+            participationImages.add(ParticipationImage.createParticipationImage(++seq, fileName));
+        }
+        
         Participation participation = Participation.createParticipation(saveDTO.getContent(), member, board, participationImages);
-        participationRepository.save(participation);
+        //participationRepository.save(participation);
     }
 
     public void deleteParticipation(Long participationId) {
@@ -117,16 +136,26 @@ public class ParticipationService {
      * 2. 변경할 이미지 없이 내용만 변경된다면 내용을 변경하는 API 를 호출한다
      */
     public ImageResponseDTO uploadImage(ImageSaveDTO imageDTO) {
+        Long boardId = imageDTO.getBoardId();
+        int sequence = imageDTO.getSequence();
+
+        BoardEntity board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new ParticipationException(NOT_FOUND, FAIL, "게시글이 존재하지 않습니다"));
+        List<BoardPathImageEntity> boardPathImageEntityList = board.getBoardFileEntity().getBoardPathImageEntityList();
+        // 도착지를 먼저 저장하시니...내가 정렬을 해야지...;;
+        boardPathImageEntityList.sort(Comparator.comparing(BoardPathImageEntity::getLocationOnRoute));
+        double latitude = boardPathImageEntityList.get(sequence - 1).getLatitude();
+        double longitude = boardPathImageEntityList.get(sequence - 1).getLongitude();
+
         String url = "modifyURL";
         MultipartFile file = imageDTO.getFile();
         double[] locationInfo = FileUtils.getLocationInfo(file);
 
-        /**
-         * 여기서 Board 이미지의 위치정보와 비교
-         * 위치정보가 유사하다면 OK
-         */
-        Long boardId = imageDTO.getBoardId();
-        int sequence = imageDTO.getSequence();
+        double distance = FileUtils.calDistance(locationInfo[0], locationInfo[1], latitude, longitude);
+        log.info(sequence + "번째 지점 distance = {}", distance);
+        if (distance > 5) {
+            throw new ParticipationException(BAD_REQUEST, FAIL, sequence + "번째 지점의 거리가 멀리 떨어져있습니다. 챌린지 지점과의 거리는 5m 이하여야 합니다. 현재거리 = " + (int) distance + "m");
+        }
 
         /*
         try {

--- a/vitalroutes/src/main/java/swyg/vitalroutes/security/filter/JwtVerifyFilter.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/security/filter/JwtVerifyFilter.java
@@ -26,8 +26,8 @@ public class JwtVerifyFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
 
-    private static final String[] whitelist = {"/", "/member/duplicateCheck" ,"/member/signUp", "/member/login", "/token/refresh", "/post/**", "/post", "/board/**", "/board",
-            "/swagger-ui/**", "/v3/api-docs", "/v3/api-docs/**", "/oauth2/**"};
+    private static final String[] whitelist = {"/", "/oauth2/**", "/member/duplicateCheck" ,"/member/signUp", "/member/login", "/member/password", "/token/refresh",
+            "/swagger-ui/**", "/v3/api-docs", "/v3/api-docs/**"};
 
     // 필터를 거치지 않을 URL 을 설정하고, true 를 return 하면 현재 필터를 건너뛰고 다음 필터로 이동
     @Override

--- a/vitalroutes/src/main/java/swyg/vitalroutes/security/utils/JwtConstants.java
+++ b/vitalroutes/src/main/java/swyg/vitalroutes/security/utils/JwtConstants.java
@@ -1,7 +1,7 @@
 package swyg.vitalroutes.security.utils;
 
 public class JwtConstants {
-    public static final int ACCESS_EXP_TIME = 10;   // 10분
+    public static final int ACCESS_EXP_TIME = 60;   // 1시간
     public static final int REFRESH_EXP_TIME = 60 * 24;   // 24시간
 
     public static final String JWT_HEADER = "Authorization";

--- a/vitalroutes/src/main/resources/application.yml
+++ b/vitalroutes/src/main/resources/application.yml
@@ -68,6 +68,6 @@ jwt:
 kakao:
   login:
     client-id: ENC(DINFbAY/RI0maEuCPDXuQcCQNp4+CxtI7O+wFoDI1ohNpHMAWvKNo71lDMLPaAy3)
-    redirect-uri: ENC(io/BNG3FIRVo5Elr8qJvP26KazkACWMxO9keK11My/JZZ1jUrvAcvHwAIhuV1j+J)
+    redirect-uri: ENC(Cwne+i2w5JVZ1nZ8+8m0VsTdcIsYwnAVm/oMKbeYO9OZg5+cGWb05WBUNUmL5V2VmpqlypTsYgg=)
     #redirect-uri: http://localhost:8080/kakaologin
     #redirect-uri: http://localhost:8080/oauth2/kakao


### PR DESCRIPTION
### 챌린지 연결

- 챌린지 참여 게시글 등록, 수정 시 게시글 이미지의 위치정보와 비교
- 5m 이내인 경우에만 등록, 수정 가능

### 프론트 연결

- 카카오 리다이렉트 URL : https://vital-routes.vercel.app/member/kakao
- 비밀번호 재설정 URL : https://vital-routes.vercel.app/member/password/xxxxx
   - xxxx 는 전달하는 토큰값
   - 비밀번호 변경 요청 시 `서버URL/member/password/xxxxx` 로 요청해야함

### S3 이미지

- 기존에 주석처리 해두었던 s3 이미지 업로드 주석 해제

close #26 